### PR TITLE
[codex] add map state scaffold

### DIFF
--- a/db/store.go
+++ b/db/store.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"strings"
+	"time"
 
 	sqlc "github.com/MeshCore-Tower/tower-server/db/sqlc"
 	"github.com/MeshCore-Tower/tower-server/internal/api"
@@ -19,11 +22,12 @@ import (
 )
 
 type Store struct {
-	q *sqlc.Queries
+	q    *sqlc.Queries
+	pool *pgxpool.Pool
 }
 
 func New(pool *pgxpool.Pool) *Store {
-	return &Store{q: sqlc.New(pool)}
+	return &Store{q: sqlc.New(pool), pool: pool}
 }
 
 // UpsertObserver upserts the observers row keyed on pubkey.
@@ -201,6 +205,211 @@ func (s *Store) ResolvePathHashes(ctx context.Context, iata string, hashes [][]b
 	return ids, nil
 }
 
+// GetMapState returns the sanitized, mappable state used by the Tower web map.
+// Route topology remains empty until ordered per-hop path confidence is complete.
+func (s *Store) GetMapState(ctx context.Context, filter api.MapStateFilter) (*api.MapState, error) {
+	iatas := normalizeMapIATAs(filter.IATAs)
+
+	nodes, err := s.listMapNodes(ctx, iatas)
+	if err != nil {
+		return nil, err
+	}
+	observers, err := s.listMapObservers(ctx, iatas)
+	if err != nil {
+		return nil, err
+	}
+	activity, err := s.mapActivitySummary(ctx, iatas)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.MapState{
+		ServerTime: time.Now().UnixMilli(),
+		Scope: api.MapScope{
+			IATAs:    iatas,
+			RegionID: filter.RegionID,
+		},
+		Metadata: api.MapMetadata{
+			Basemap:            "openfreemap",
+			RoutesComplete:     false,
+			RoutesStatus:       "blocked_by_ordered_path_confidence",
+			LiveDefaultEnabled: false,
+		},
+		Nodes:           nodes,
+		Observers:       observers,
+		Routes:          []api.MapRoute{},
+		ActivitySummary: activity,
+	}, nil
+}
+
+func (s *Store) listMapNodes(ctx context.Context, iatas []string) ([]api.MapNode, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT
+  n.id,
+  n.node_type,
+  n.name,
+  n.latitude,
+  n.longitude,
+  n.first_seen,
+  n.last_seen,
+  COALESCE(SUM(ni.observation_count), 0)::bigint AS activity_count,
+  COALESCE(
+    array_agg(DISTINCT trim(ni.iata)::text ORDER BY trim(ni.iata)::text)
+      FILTER (WHERE ni.iata IS NOT NULL),
+    ARRAY[]::text[]
+  ) AS iatas_heard_in
+FROM nodes n
+LEFT JOIN node_iatas ni ON ni.node_id = n.id
+WHERE n.latitude IS NOT NULL
+  AND n.longitude IS NOT NULL
+  AND (
+    $1::text[] IS NULL
+    OR EXISTS (
+      SELECT 1
+      FROM node_iatas scoped
+      WHERE scoped.node_id = n.id
+        AND trim(scoped.iata)::text = ANY($1::text[])
+    )
+  )
+GROUP BY n.id
+ORDER BY n.last_seen DESC
+LIMIT 2000
+`, mapIATAParam(iatas))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	nodes := []api.MapNode{}
+	for rows.Next() {
+		var id uuid.UUID
+		var nodeType int16
+		var name *string
+		var lat, lng float64
+		var firstSeen, lastSeen time.Time
+		var activityCount int64
+		var heardIn []string
+		if err := rows.Scan(&id, &nodeType, &name, &lat, &lng, &firstSeen, &lastSeen, &activityCount, &heardIn); err != nil {
+			return nil, err
+		}
+		role := mapNodeRole(nodeType)
+		nodes = append(nodes, api.MapNode{
+			ID:            id.String(),
+			Label:         mapDisplayLabel(name, role),
+			Role:          role,
+			Lat:           lat,
+			Lng:           lng,
+			FirstSeen:     firstSeen.UnixMilli(),
+			LastSeen:      lastSeen.UnixMilli(),
+			IATAsHeardIn:  heardIn,
+			ActivityCount: activityCount,
+		})
+	}
+	return nodes, rows.Err()
+}
+
+func (s *Store) listMapObservers(ctx context.Context, iatas []string) ([]api.MapObserver, error) {
+	rows, err := s.pool.Query(ctx, `
+WITH latest_iata AS (
+  SELECT DISTINCT ON (observer_id)
+    observer_id,
+    trim(iata)::text AS iata
+  FROM packet_observations
+  ORDER BY observer_id, heard_at DESC
+),
+latest_location AS (
+  SELECT DISTINCT ON (observer_id)
+    observer_id,
+    NULLIF(trim(iata)::text, '') AS iata,
+    latitude,
+    longitude
+  FROM observer_locations
+  WHERE latitude IS NOT NULL
+    AND longitude IS NOT NULL
+  ORDER BY observer_id, reported_at DESC
+)
+SELECT
+  o.id,
+  o.display_name,
+  o.observer_type,
+  COALESCE(ll.iata, li.iata, '') AS iata,
+  ll.latitude,
+  ll.longitude,
+  o.last_seen,
+  COALESCE(o.observation_count, 0)::bigint AS observation_count,
+  o.last_seen >= NOW() - INTERVAL '5 minutes' AS online
+FROM observers o
+JOIN latest_location ll ON ll.observer_id = o.id
+LEFT JOIN latest_iata li ON li.observer_id = o.id
+WHERE (
+  $1::text[] IS NULL
+  OR COALESCE(ll.iata, li.iata, '') = ANY($1::text[])
+)
+ORDER BY o.last_seen DESC
+LIMIT 1000
+`, mapIATAParam(iatas))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	observers := []api.MapObserver{}
+	for rows.Next() {
+		var id uuid.UUID
+		var name, observerType *string
+		var iata string
+		var lat, lng float64
+		var lastSeen time.Time
+		var observationCount int64
+		var online bool
+		if err := rows.Scan(&id, &name, &observerType, &iata, &lat, &lng, &lastSeen, &observationCount, &online); err != nil {
+			return nil, err
+		}
+		observers = append(observers, api.MapObserver{
+			ID:               id.String(),
+			Label:            mapObserverLabel(name, iata),
+			Type:             ptrString(observerType, "unknown"),
+			IATA:             iata,
+			Lat:              lat,
+			Lng:              lng,
+			Online:           online,
+			LastSeen:         lastSeen.UnixMilli(),
+			ObservationCount: observationCount,
+		})
+	}
+	return observers, rows.Err()
+}
+
+func (s *Store) mapActivitySummary(ctx context.Context, iatas []string) (api.MapActivitySummary, error) {
+	var summary api.MapActivitySummary
+	var lastHeard pgtype.Timestamptz
+	err := s.pool.QueryRow(ctx, `
+SELECT
+  COUNT(DISTINCT packet_hash)::bigint AS packets_24h,
+  COUNT(*)::bigint AS observations_24h,
+  COUNT(DISTINCT observer_id)::bigint AS active_observers_24h,
+  COUNT(DISTINCT trim(iata)::text)::bigint AS active_iatas_24h,
+  MAX(heard_at) AS last_heard_at
+FROM packet_observations
+WHERE heard_at > NOW() - INTERVAL '24 hours'
+  AND ($1::text[] IS NULL OR trim(iata)::text = ANY($1::text[]))
+`, mapIATAParam(iatas)).Scan(
+		&summary.Packets24h,
+		&summary.Observations24h,
+		&summary.ActiveObservers24h,
+		&summary.ActiveIATAs24h,
+		&lastHeard,
+	)
+	if err != nil {
+		return api.MapActivitySummary{}, err
+	}
+	if lastHeard.Valid {
+		ms := lastHeard.Time.UnixMilli()
+		summary.LastHeardAt = &ms
+	}
+	return summary, nil
+}
+
 // UpsertChannel upserts a channel row by (hash, keyFingerprint) and returns its integer ID.
 // Pass nil keyFingerprint to record a hash-only row when the key is unknown.
 // name and hashtag are optional metadata stored on the channel row.
@@ -347,4 +556,90 @@ func (s *Store) UpsertRegionIATA(ctx context.Context, regionID int32, iata strin
 		RegionID: regionID,
 		Iata:     iata,
 	})
+}
+
+func normalizeMapIATAs(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		iata := strings.ToUpper(strings.TrimSpace(value))
+		if iata == "" || iata == "*" {
+			continue
+		}
+		if _, ok := seen[iata]; ok {
+			continue
+		}
+		seen[iata] = struct{}{}
+		out = append(out, iata)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mapIATAParam(iatas []string) any {
+	if len(iatas) == 0 {
+		return nil
+	}
+	return iatas
+}
+
+func mapNodeRole(nodeType int16) string {
+	switch nodeType {
+	case 1:
+		return "companion"
+	case 2:
+		return "repeater"
+	case 3:
+		return "room_server"
+	default:
+		return "unknown"
+	}
+}
+
+func mapDisplayLabel(name *string, role string) string {
+	if name != nil {
+		trimmed := strings.TrimSpace(*name)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	switch role {
+	case "repeater":
+		return "Repeater"
+	case "room_server":
+		return "Room server"
+	case "companion":
+		return "Companion"
+	default:
+		return "Node"
+	}
+}
+
+func mapObserverLabel(name *string, iata string) string {
+	if name != nil {
+		trimmed := strings.TrimSpace(*name)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	if iata != "" {
+		return fmt.Sprintf("%s observer", iata)
+	}
+	return "Observer"
+}
+
+func ptrString(value *string, fallback string) string {
+	if value == nil {
+		return fallback
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
 }

--- a/internal/api/handlers/map.go
+++ b/internal/api/handlers/map.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/MeshCore-Tower/tower-server/internal/api"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// MapRouter mounts read-only map endpoints.
+//
+// GET /map/state?iata=YOW
+// GET /map/state?regionId=1
+func MapRouter(reader api.Reader) http.Handler {
+	r := chi.NewRouter()
+
+	r.Get("/state", func(w http.ResponseWriter, r *http.Request) {
+		filter, ok := mapStateFilter(w, r, reader)
+		if !ok {
+			return
+		}
+
+		state, err := reader.GetMapState(r.Context(), filter)
+		if err != nil {
+			respond(w, http.StatusInternalServerError, map[string]string{"error": "map state unavailable"})
+			return
+		}
+		respond(w, http.StatusOK, state)
+	})
+
+	return r
+}
+
+func mapStateFilter(w http.ResponseWriter, r *http.Request, reader api.Reader) (api.MapStateFilter, bool) {
+	iata := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("iata")))
+	regionIDRaw := strings.TrimSpace(r.URL.Query().Get("regionId"))
+	if iata != "" && iata != "*" && regionIDRaw != "" {
+		respond(w, http.StatusBadRequest, map[string]string{"error": "use either iata or regionId, not both"})
+		return api.MapStateFilter{}, false
+	}
+
+	if iata != "" && iata != "*" {
+		if len(iata) != 3 {
+			respond(w, http.StatusBadRequest, map[string]string{"error": "iata must be a 3-letter code"})
+			return api.MapStateFilter{}, false
+		}
+		return api.MapStateFilter{IATAs: []string{iata}}, true
+	}
+
+	if regionIDRaw == "" {
+		return api.MapStateFilter{}, true
+	}
+
+	regionID, err := strconv.ParseInt(regionIDRaw, 10, 32)
+	if err != nil || regionID <= 0 {
+		respond(w, http.StatusBadRequest, map[string]string{"error": "invalid regionId"})
+		return api.MapStateFilter{}, false
+	}
+
+	region, err := reader.GetRegion(r.Context(), int32(regionID))
+	if err != nil {
+		respond(w, http.StatusNotFound, map[string]string{"error": "region not found"})
+		return api.MapStateFilter{}, false
+	}
+	id := int(regionID)
+	return api.MapStateFilter{IATAs: region.IATAs, RegionID: &id}, true
+}

--- a/internal/api/handlers/map_test.go
+++ b/internal/api/handlers/map_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MeshCore-Tower/tower-server/internal/api"
+)
+
+func TestMapStateFiltersByIATA(t *testing.T) {
+	reader := &fakeMapReader{}
+	req := httptest.NewRequest(http.MethodGet, "/state?iata=yow", nil)
+	rec := httptest.NewRecorder()
+
+	MapRouter(reader).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := reader.filter.IATAs; len(got) != 1 || got[0] != "YOW" {
+		t.Fatalf("IATAs = %#v, want [YOW]", got)
+	}
+
+	var state api.MapState
+	if err := json.NewDecoder(rec.Body).Decode(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state.Metadata.LiveDefaultEnabled {
+		t.Fatal("live map layer must default off")
+	}
+}
+
+func TestMapStateRejectsMixedScopes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/state?iata=YOW&regionId=1", nil)
+	rec := httptest.NewRecorder()
+
+	MapRouter(&fakeMapReader{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+type fakeMapReader struct {
+	filter api.MapStateFilter
+}
+
+func (f *fakeMapReader) ListIATAs(context.Context) ([]api.IATA, error) {
+	return nil, nil
+}
+
+func (f *fakeMapReader) GetIATA(context.Context, string) (*api.IATA, error) {
+	return nil, nil
+}
+
+func (f *fakeMapReader) ListRegions(context.Context) ([]api.RegionSummary, error) {
+	return nil, nil
+}
+
+func (f *fakeMapReader) GetRegion(context.Context, int32) (*api.Region, error) {
+	return &api.Region{IATAs: []string{"YOW", "YUL"}}, nil
+}
+
+func (f *fakeMapReader) GetMapState(_ context.Context, filter api.MapStateFilter) (*api.MapState, error) {
+	f.filter = filter
+	return &api.MapState{
+		ServerTime: 1,
+		Scope:      api.MapScope{IATAs: filter.IATAs, RegionID: filter.RegionID},
+		Metadata: api.MapMetadata{
+			Basemap:            "openfreemap",
+			RoutesComplete:     false,
+			RoutesStatus:       "blocked_by_ordered_path_confidence",
+			LiveDefaultEnabled: false,
+		},
+		Nodes:     []api.MapNode{},
+		Observers: []api.MapObserver{},
+		Routes:    []api.MapRoute{},
+	}, nil
+}

--- a/internal/api/reader.go
+++ b/internal/api/reader.go
@@ -19,6 +19,82 @@ type Region struct {
 	IATAs       []string `json:"iatas"`
 }
 
+type MapStateFilter struct {
+	IATAs    []string
+	RegionID *int
+}
+
+type MapScope struct {
+	IATAs    []string `json:"iatas"`
+	RegionID *int     `json:"regionId,omitempty"`
+}
+
+type MapMetadata struct {
+	Basemap            string `json:"basemap"`
+	RoutesComplete     bool   `json:"routesComplete"`
+	RoutesStatus       string `json:"routesStatus"`
+	LiveDefaultEnabled bool   `json:"liveDefaultEnabled"`
+}
+
+type MapNode struct {
+	ID            string   `json:"id"`
+	Label         string   `json:"label"`
+	Role          string   `json:"role"`
+	Lat           float64  `json:"lat"`
+	Lng           float64  `json:"lng"`
+	FirstSeen     int64    `json:"firstSeen"`
+	LastSeen      int64    `json:"lastSeen"`
+	IATAsHeardIn  []string `json:"iatasHeardIn"`
+	ActivityCount int64    `json:"activityCount"`
+}
+
+type MapObserver struct {
+	ID               string  `json:"id"`
+	Label            string  `json:"label"`
+	Type             string  `json:"type"`
+	IATA             string  `json:"iata"`
+	Lat              float64 `json:"lat"`
+	Lng              float64 `json:"lng"`
+	Online           bool    `json:"online"`
+	LastSeen         int64   `json:"lastSeen"`
+	ObservationCount int64   `json:"observationCount"`
+}
+
+type MapRouteEndpoint struct {
+	NodeID string  `json:"nodeId"`
+	Label  string  `json:"label"`
+	Lat    float64 `json:"lat"`
+	Lng    float64 `json:"lng"`
+}
+
+type MapRoute struct {
+	ID                string           `json:"id"`
+	From              MapRouteEndpoint `json:"from"`
+	To                MapRouteEndpoint `json:"to"`
+	PacketCount       int              `json:"packetCount"`
+	LastHeard         int64            `json:"lastHeard"`
+	PayloadTypeNames  []string         `json:"payloadTypeNames"`
+	ResolutionQuality string           `json:"resolutionQuality"`
+}
+
+type MapActivitySummary struct {
+	Packets24h         int64  `json:"packets24h"`
+	Observations24h    int64  `json:"observations24h"`
+	ActiveObservers24h int64  `json:"activeObservers24h"`
+	ActiveIATAs24h     int64  `json:"activeIatas24h"`
+	LastHeardAt        *int64 `json:"lastHeardAt"`
+}
+
+type MapState struct {
+	ServerTime      int64              `json:"serverTime"`
+	Scope           MapScope           `json:"scope"`
+	Metadata        MapMetadata        `json:"metadata"`
+	Nodes           []MapNode          `json:"nodes"`
+	Observers       []MapObserver      `json:"observers"`
+	Routes          []MapRoute         `json:"routes"`
+	ActivitySummary MapActivitySummary `json:"activitySummary"`
+}
+
 // IATA represents a known airport/location code used to group observers and packets.
 // DisplayName, Lat and Lng are optional — they are set via config file override
 // or remain nil if the IATA was auto-created from packet traffic.
@@ -42,4 +118,6 @@ type Reader interface {
 	// GetRegion returns full detail for a single region including its associated IATA codes.
 	// Returns nil, pgx.ErrNoRows if the region is not found.
 	GetRegion(ctx context.Context, regionID int32) (*Region, error)
+	// GetMapState returns sanitized, mappable state for the Tower map page.
+	GetMapState(ctx context.Context, filter MapStateFilter) (*MapState, error)
 }

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -26,6 +26,7 @@ import (
 //	  /iatas           → iatas subrouter
 //	  /regions         → regions subrouter
 //	  /stats           → stats subrouter
+//	  /map             → map state subrouter
 //
 // The private group is stubbed and ready for the auth middleware drop-in
 // described in Future Features → Admin authentication.
@@ -54,6 +55,7 @@ func New(h *hub.Hub, reader api.Reader) http.Handler {
 			r.Mount("/iatas", handlers.IATAsRouter(reader))
 			r.Mount("/regions", handlers.RegionsRouter(reader))
 			r.Mount("/stats", handlers.StatsRouter())
+			r.Mount("/map", handlers.MapRouter(reader))
 		})
 
 		// Private group — auth middleware applied.


### PR DESCRIPTION
## Summary
- Adds a Tower-native `GET /api/v1/map/state` scaffold with `iata` or `regionId` filtering.
- Returns sanitized map state records for nodes, observers, activity summary, and metadata.
- Leaves map routes intentionally empty until ordered path confidence exists.
- Adds focused handler coverage for IATA filtering/default Live policy metadata and invalid mixed scope.

## Deficiencies / not done yet
- `routes` are deliberately empty and `routesStatus` is `blocked_by_ordered_path_confidence` because current path resolution loses hop order and confidence.
- Existing resolver work still needs one result per hop with `high`, `ambiguous`, and `none` states before route rendering can be honest.
- Observer points depend on `observer_locations`; if ingest does not populate that table, the observer layer will be empty.
- This PR uses direct pgx queries for the scaffold instead of moving through generated sqlc queries; that can be tightened once the contract stabilizes.
- No map-safe live WS payload is added here. REST remains the source of truth.

## Roadmap
1. Stabilize the map state contract against frontend usage.
2. Implement ordered per-hop path resolution and block route output unless every hop is high confidence.
3. Add route records only after ambiguity handling and privacy redaction rules are accepted.
4. Add map-safe live payloads if the frontend needs them for the default-off Live layer.

## Verification
- `go test ./...`
