### PR TITLE
bake db migrations into app on start

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -6,7 +6,10 @@ COPY . .
 RUN go build -o tower ./cmd/tower
 
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata postgresql-client
 WORKDIR /app
 COPY --from=builder /app/tower .
-ENTRYPOINT ["./tower"]
+COPY db/migrations/ ./migrations/
+COPY .build/docker-entrypoint.sh .
+RUN chmod +x docker-entrypoint.sh
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/.build/docker-entrypoint.sh
+++ b/.build/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+if [ -n "$POSTGRES_DSN" ]; then
+  echo "Running database migrations..."
+
+  psql "$POSTGRES_DSN" -c "CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );"
+
+  for f in /app/migrations/*.sql; do
+    name=$(basename "$f")
+    already=$(psql "$POSTGRES_DSN" -tAc "SELECT 1 FROM schema_migrations WHERE filename = '$name'")
+    if [ "$already" != "1" ]; then
+      echo "  Applying $name..."
+      psql "$POSTGRES_DSN" -f "$f"
+      psql "$POSTGRES_DSN" -c "INSERT INTO schema_migrations (filename) VALUES ('$name');"
+    else
+      echo "  Skipping $name (already applied)"
+    fi
+  done
+
+  echo "Migrations complete."
+fi
+
+exec ./tower "$@"


### PR DESCRIPTION
Bake the DB migrations into the docker container start at boot.

This way the user running docker compose up dosn't need to worry about having that file on hand.