### PR TITLE
fix(seed): make UpsertIATADetails a true upsert

### DIFF
--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -17,11 +17,12 @@ SELECT * FROM iata_codes WHERE iata = $1;
 SELECT * FROM iata_codes ORDER BY iata;
 
 -- name: UpsertIATADetails :exec
-UPDATE iata_codes SET
-    display_name = $2,
-    approx_lat   = $3,
-    approx_lng   = $4
-WHERE iata = $1;
+INSERT INTO iata_codes (iata, display_name, approx_lat, approx_lng)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (iata) DO UPDATE SET
+    display_name = EXCLUDED.display_name,
+    approx_lat   = EXCLUDED.approx_lat,
+    approx_lng   = EXCLUDED.approx_lng;
 
 -- ============================================================
 -- TRANSPORT CODES

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -3025,11 +3025,12 @@ func (q *Queries) UpsertIATA(ctx context.Context, iata string) error {
 }
 
 const upsertIATADetails = `-- name: UpsertIATADetails :exec
-UPDATE iata_codes SET
-    display_name = $2,
-    approx_lat   = $3,
-    approx_lng   = $4
-WHERE iata = $1
+INSERT INTO iata_codes (iata, display_name, approx_lat, approx_lng)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (iata) DO UPDATE SET
+    display_name = EXCLUDED.display_name,
+    approx_lat   = EXCLUDED.approx_lat,
+    approx_lng   = EXCLUDED.approx_lng
 `
 
 type UpsertIATADetailsParams struct {


### PR DESCRIPTION
## What this PR does

Fixes a bug where adding a new IATA to the config results in `display_name`, `approx_lat`, and `approx_lng` remaining NULL in `iata_codes`.

**Root cause:** `UpsertIATADetails` was a plain `UPDATE ... WHERE iata = $1`. If the row did not already exist (i.e. the IATA was being added for the first time), the UPDATE silently affected zero rows and the metadata was lost.

**Fix:** Change the query to `INSERT ... ON CONFLICT (iata) DO UPDATE SET ...` so the row is atomically created (if missing) or updated (if present). This matches the function name and follows the same pattern already used by `UpsertTransportScope` elsewhere in the codebase.

**Steps to reproduce:**
1. Add a new IATA to `config.yaml` (e.g. `MME: { name: Teesside, lat: 54.5, lng: -1.4 }`)
2. Restart the server
3. `SELECT * FROM iata_codes WHERE iata = 'MME'` → display_name/lat/lng are NULL

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Docs / config
- [ ] Other:

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] New pure functions have unit tests
- [x] DB changes include migration SQL and `sqlc generate` has been run
- [ ] API changes include swagger annotations and `swag init` has been run
- [ ] `docs/` is committed if swagger was regenerated
- [ ] New dependencies are added to `SHOULDERS.md`
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)

## Testing notes

Reproduced in a live deployment: after adding a new IATA (`MME`) to the config, the `/api/v1/iatas` endpoint returned the code but with null metadata. After applying this fix, details are correctly populated on first boot without needing a separate `UpsertIATA` call beforehand.