### PR TITLE
1. Coalesce presence writes in memory and flush on an interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ telemetry:
 packets:
   retention: 720h # how long to keep packets and observations (default: 30 days)
 
+# Presence write coalescing.
+# Observer last_seen and packet last_heard_at bumps are batched in memory and
+# flushed on an interval instead of writing one row per observation. An
+# unclean shutdown loses at most one interval of presence freshness.
+presence:
+  flush_interval: 30s # how often coalesced bumps are flushed (default: 30s)
+  packet_ttl: 30s # how long a quiet packet stays coalesced before writing through again (default: 30s)
+
 # WebSocket settings.
 websocket:
   max_connections_per_ip: 5 # default: 5

--- a/cmd/beacon/main.go
+++ b/cmd/beacon/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/MeshCore-Beacon/beacon-server/internal/iatadb"
 	"github.com/MeshCore-Beacon/beacon-server/internal/ingest"
 	"github.com/MeshCore-Beacon/beacon-server/internal/keystore"
+	"github.com/MeshCore-Beacon/beacon-server/internal/presence"
 	"github.com/MeshCore-Beacon/beacon-server/internal/scopestore"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -110,6 +111,11 @@ func main() {
 	}
 
 	store := db.New(pool)
+
+	// ── Presence write coalescing ────────────────────────────────────────────
+	// Ingest writes go through the coalescer; reads keep using the store.
+	coalescer := presence.New(store, resolved.PresenceFlushInterval, resolved.PresencePacketTTL)
+	go coalescer.Run(ctx)
 
 	// ── Redis cache layer ────────────────────────────────────────────────────
 	var reader api.Reader = store
@@ -209,7 +215,7 @@ func main() {
 			TelemetryResolution: resolved.TelemetryResolution,
 			AllowedIATAs:        allowedIATAs,
 		},
-		store,
+		coalescer,
 		h,
 		keys,
 		scopes,
@@ -224,7 +230,7 @@ func main() {
 			TelemetryResolution: resolved.TelemetryResolution,
 			AllowedIATAs:        allowedIATAs,
 		},
-		store,
+		coalescer,
 		h,
 		keys,
 		scopes,
@@ -272,6 +278,7 @@ func main() {
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Printf("server shutdown error: %v", err)
 	}
+	coalescer.Flush(shutdownCtx)
 }
 
 // getEnv returns the value of an env var and logs a warning if it is unset.

--- a/db/presence.go
+++ b/db/presence.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package db
+
+import (
+	"context"
+	"time"
+
+	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (s *Store) TouchObservers(ctx context.Context, ids []uuid.UUID, seen []time.Time, counts []int32) error {
+	return s.q.TouchObservers(ctx, sqlc.TouchObserversParams{
+		Column1: ids,
+		Column2: toTimestamptzs(seen),
+		Column3: counts,
+	})
+}
+
+func (s *Store) TouchObserverBrokers(ctx context.Context, ids []uuid.UUID, brokers []string, seen []time.Time) error {
+	return s.q.TouchObserverBrokers(ctx, sqlc.TouchObserverBrokersParams{
+		Column1: ids,
+		Column2: brokers,
+		Column3: toTimestamptzs(seen),
+	})
+}
+
+func (s *Store) TouchPackets(ctx context.Context, hashes [][]byte, heard []time.Time) error {
+	return s.q.TouchPackets(ctx, sqlc.TouchPacketsParams{
+		Column1: hashes,
+		Column2: toTimestamptzs(heard),
+	})
+}
+
+func toTimestamptzs(ts []time.Time) []pgtype.Timestamptz {
+	out := make([]pgtype.Timestamptz, len(ts))
+	for i, t := range ts {
+		out[i] = pgtype.Timestamptz{Time: t, Valid: true}
+	}
+	return out
+}

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -109,6 +109,19 @@ UPDATE observers SET
 WHERE public_key = $1
 RETURNING id;
 
+-- name: TouchObservers :exec
+-- Batched flush of coalesced presence bumps. GREATEST keeps a late flush
+-- from regressing a newer write-through (e.g. a status update).
+UPDATE observers o SET
+  last_seen         = GREATEST(o.last_seen, v.seen),
+  observation_count = COALESCE(o.observation_count, 0) + v.delta
+FROM (
+  SELECT unnest($1::uuid[]) AS id,
+         unnest($2::timestamptz[]) AS seen,
+         unnest($3::int[]) AS delta
+) v
+WHERE o.id = v.id;
+
 -- name: UpsertObserverScope :exec
 INSERT INTO observer_scopes (observer_id, scope_id, last_seen)
 VALUES ($1, $2, NOW())
@@ -270,6 +283,17 @@ ON CONFLICT (observer_id, broker_name) DO UPDATE SET
   last_seen      = NOW(),
   last_packet_at = NOW();
 
+-- name: TouchObserverBrokers :exec
+UPDATE observer_brokers ob SET
+  last_seen      = GREATEST(ob.last_seen, v.seen),
+  last_packet_at = GREATEST(ob.last_packet_at, v.seen)
+FROM (
+  SELECT unnest($1::uuid[]) AS observer_id,
+         unnest($2::text[]) AS broker_name,
+         unnest($3::timestamptz[]) AS seen
+) v
+WHERE ob.observer_id = v.observer_id AND ob.broker_name = v.broker_name;
+
 -- ============================================================
 -- PACKETS
 -- ============================================================
@@ -302,6 +326,15 @@ AS inserted;
 
 -- name: SetPacketDecrypted :exec
 UPDATE packets SET decrypted = true WHERE packet_hash = $1;
+
+-- name: TouchPackets :exec
+UPDATE packets p SET
+  last_heard_at = GREATEST(p.last_heard_at, v.heard)
+FROM (
+  SELECT unnest($1::bytea[]) AS packet_hash,
+         unnest($2::timestamptz[]) AS heard
+) v
+WHERE p.packet_hash = v.packet_hash;
 
 -- name: GetPacketByHash :one
 SELECT p.*, ts.name AS scope_name,

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -1036,6 +1036,48 @@ func (mr *MockQuerierMockRecorder) SetPacketDecrypted(ctx, packetHash any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPacketDecrypted", reflect.TypeOf((*MockQuerier)(nil).SetPacketDecrypted), ctx, packetHash)
 }
 
+// TouchObserverBrokers mocks base method.
+func (m *MockQuerier) TouchObserverBrokers(ctx context.Context, arg db.TouchObserverBrokersParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TouchObserverBrokers", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TouchObserverBrokers indicates an expected call of TouchObserverBrokers.
+func (mr *MockQuerierMockRecorder) TouchObserverBrokers(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TouchObserverBrokers", reflect.TypeOf((*MockQuerier)(nil).TouchObserverBrokers), ctx, arg)
+}
+
+// TouchObservers mocks base method.
+func (m *MockQuerier) TouchObservers(ctx context.Context, arg db.TouchObserversParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TouchObservers", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TouchObservers indicates an expected call of TouchObservers.
+func (mr *MockQuerierMockRecorder) TouchObservers(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TouchObservers", reflect.TypeOf((*MockQuerier)(nil).TouchObservers), ctx, arg)
+}
+
+// TouchPackets mocks base method.
+func (m *MockQuerier) TouchPackets(ctx context.Context, arg db.TouchPacketsParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TouchPackets", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TouchPackets indicates an expected call of TouchPackets.
+func (mr *MockQuerierMockRecorder) TouchPackets(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TouchPackets", reflect.TypeOf((*MockQuerier)(nil).TouchPackets), ctx, arg)
+}
+
 // UpdateObserverStatus mocks base method.
 func (m *MockQuerier) UpdateObserverStatus(ctx context.Context, arg db.UpdateObserverStatusParams) (uuid.UUID, error) {
 	m.ctrl.T.Helper()

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -140,6 +140,11 @@ type Querier interface {
 	SetNodeMultibytePaths(ctx context.Context, id uuid.UUID) error
 	SetNodeMultibyteTraces(ctx context.Context, id uuid.UUID) error
 	SetPacketDecrypted(ctx context.Context, packetHash []byte) error
+	TouchObserverBrokers(ctx context.Context, arg TouchObserverBrokersParams) error
+	// Batched flush of coalesced presence bumps. GREATEST keeps a late flush
+	// from regressing a newer write-through (e.g. a status update).
+	TouchObservers(ctx context.Context, arg TouchObserversParams) error
+	TouchPackets(ctx context.Context, arg TouchPacketsParams) error
 	UpdateObserverStatus(ctx context.Context, arg UpdateObserverStatusParams) (uuid.UUID, error)
 	// ============================================================
 	// CHANNELS

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -2959,6 +2959,74 @@ func (q *Queries) SetPacketDecrypted(ctx context.Context, packetHash []byte) err
 	return err
 }
 
+const touchObserverBrokers = `-- name: TouchObserverBrokers :exec
+UPDATE observer_brokers ob SET
+  last_seen      = GREATEST(ob.last_seen, v.seen),
+  last_packet_at = GREATEST(ob.last_packet_at, v.seen)
+FROM (
+  SELECT unnest($1::uuid[]) AS observer_id,
+         unnest($2::text[]) AS broker_name,
+         unnest($3::timestamptz[]) AS seen
+) v
+WHERE ob.observer_id = v.observer_id AND ob.broker_name = v.broker_name
+`
+
+type TouchObserverBrokersParams struct {
+	Column1 []uuid.UUID          `json:"column_1"`
+	Column2 []string             `json:"column_2"`
+	Column3 []pgtype.Timestamptz `json:"column_3"`
+}
+
+func (q *Queries) TouchObserverBrokers(ctx context.Context, arg TouchObserverBrokersParams) error {
+	_, err := q.db.Exec(ctx, touchObserverBrokers, arg.Column1, arg.Column2, arg.Column3)
+	return err
+}
+
+const touchObservers = `-- name: TouchObservers :exec
+UPDATE observers o SET
+  last_seen         = GREATEST(o.last_seen, v.seen),
+  observation_count = COALESCE(o.observation_count, 0) + v.delta
+FROM (
+  SELECT unnest($1::uuid[]) AS id,
+         unnest($2::timestamptz[]) AS seen,
+         unnest($3::int[]) AS delta
+) v
+WHERE o.id = v.id
+`
+
+type TouchObserversParams struct {
+	Column1 []uuid.UUID          `json:"column_1"`
+	Column2 []pgtype.Timestamptz `json:"column_2"`
+	Column3 []int32              `json:"column_3"`
+}
+
+// Batched flush of coalesced presence bumps. GREATEST keeps a late flush
+// from regressing a newer write-through (e.g. a status update).
+func (q *Queries) TouchObservers(ctx context.Context, arg TouchObserversParams) error {
+	_, err := q.db.Exec(ctx, touchObservers, arg.Column1, arg.Column2, arg.Column3)
+	return err
+}
+
+const touchPackets = `-- name: TouchPackets :exec
+UPDATE packets p SET
+  last_heard_at = GREATEST(p.last_heard_at, v.heard)
+FROM (
+  SELECT unnest($1::bytea[]) AS packet_hash,
+         unnest($2::timestamptz[]) AS heard
+) v
+WHERE p.packet_hash = v.packet_hash
+`
+
+type TouchPacketsParams struct {
+	Column1 [][]byte             `json:"column_1"`
+	Column2 []pgtype.Timestamptz `json:"column_2"`
+}
+
+func (q *Queries) TouchPackets(ctx context.Context, arg TouchPacketsParams) error {
+	_, err := q.db.Exec(ctx, touchPackets, arg.Column1, arg.Column2)
+	return err
+}
+
 const updateObserverStatus = `-- name: UpdateObserverStatus :one
 UPDATE observers SET
   display_name     = COALESCE(NULLIF($2, ''), display_name),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MeshCore-Beacon/beacon-server
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Cache       CacheConfig           `yaml:"cache"`
 	CORS        CORSConfig            `yaml:"cors"`
 	Background  BackgroundConfig      `yaml:"background"`
+	Presence    PresenceConfig        `yaml:"presence"`
 }
 
 // ResolvedConfig holds all runtime configuration with defaults applied.
@@ -37,6 +38,22 @@ type ResolvedConfig struct {
 	ViewRefreshInterval time.Duration
 	ReconfirmInterval   time.Duration
 	CleanupInterval     time.Duration
+
+	PresenceFlushInterval time.Duration
+	PresencePacketTTL     time.Duration
+}
+
+// PresenceConfig controls coalescing of presence bookkeeping writes
+// (observer last_seen, observer_brokers, packet last_heard_at bumps).
+type PresenceConfig struct {
+	// FlushInterval is how often coalesced bumps are flushed to Postgres.
+	// Defaults to 30s if not set.
+	FlushInterval duration `yaml:"flush_interval"`
+
+	// PacketTTL is how long a packet hash with no re-observations stays
+	// coalesced before the next observation writes through again.
+	// Defaults to 30s if not set.
+	PacketTTL duration `yaml:"packet_ttl"`
 }
 
 // BackgroundConfig controls the intervals for background maintenance tasks.
@@ -250,6 +267,9 @@ func Resolve(cfg *Config) ResolvedConfig {
 		ViewRefreshInterval: cfg.Background.ViewRefresh.Duration,
 		ReconfirmInterval:   cfg.Background.Reconfirm.Duration,
 		CleanupInterval:     cfg.Background.Cleanup.Duration,
+
+		PresenceFlushInterval: cfg.Presence.FlushInterval.Duration,
+		PresencePacketTTL:     cfg.Presence.PacketTTL.Duration,
 	}
 	if r.TelemetryResolution == 0 {
 		r.TelemetryResolution = time.Hour
@@ -272,13 +292,20 @@ func Resolve(cfg *Config) ResolvedConfig {
 	if r.CleanupInterval == 0 {
 		r.CleanupInterval = time.Hour
 	}
+	if r.PresenceFlushInterval == 0 {
+		r.PresenceFlushInterval = 30 * time.Second
+	}
+	if r.PresencePacketTTL == 0 {
+		r.PresencePacketTTL = 30 * time.Second
+	}
 	return r
 }
 
 func (r ResolvedConfig) String() string {
 	return fmt.Sprintf(
-		"telemetryResolution=%s telemetryRetention=%s packetRetention=%s maxConnsPerIP=%d viewRefresh=%s reconfirm=%s cleanup=%s",
+		"telemetryResolution=%s telemetryRetention=%s packetRetention=%s maxConnsPerIP=%d viewRefresh=%s reconfirm=%s cleanup=%s presenceFlush=%s presencePacketTTL=%s",
 		r.TelemetryResolution, r.TelemetryRetention, r.PacketRetention,
 		r.MaxConnsPerIP, r.ViewRefreshInterval, r.ReconfirmInterval, r.CleanupInterval,
+		r.PresenceFlushInterval, r.PresencePacketTTL,
 	)
 }

--- a/internal/presence/coalescer.go
+++ b/internal/presence/coalescer.go
@@ -1,0 +1,270 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package presence batches the per-packet presence bookkeeping (observer and
+// packet last-seen bumps) that would otherwise hit Postgres as one tiny
+// transaction per observation. Repeat writes are absorbed in memory and
+// flushed on an interval as one batched statement per table; first-time
+// writes (new observer, new packet, new broker pair) still write through so
+// rows exist before anything references them.
+package presence
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/MeshCore-Beacon/beacon-server/internal/ingest"
+	"github.com/google/uuid"
+)
+
+// Store is the database surface the coalescer decorates: the full ingest
+// interface plus the batched flush queries.
+type Store interface {
+	ingest.DB
+
+	// TouchObservers applies coalesced last_seen bumps and observation_count
+	// deltas for the given observer IDs in one statement.
+	TouchObservers(ctx context.Context, ids []uuid.UUID, seen []time.Time, counts []int32) error
+
+	// TouchObserverBrokers applies coalesced last_seen/last_packet_at bumps
+	// for the given (observer, broker) pairs in one statement.
+	TouchObserverBrokers(ctx context.Context, ids []uuid.UUID, brokers []string, seen []time.Time) error
+
+	// TouchPackets applies coalesced last_heard_at bumps for the given packet
+	// hashes in one statement.
+	TouchPackets(ctx context.Context, hashes [][]byte, heard []time.Time) error
+}
+
+type identity struct {
+	id   uuid.UUID
+	name string
+}
+
+type observerBump struct {
+	seen  time.Time
+	count int32
+}
+
+type brokerKey struct {
+	id     uuid.UUID
+	broker string
+}
+
+// Coalescer wraps a Store and absorbs repeat presence writes in memory,
+// flushing them on an interval. All other ingest.DB calls pass through.
+type Coalescer struct {
+	Store
+	flushInterval time.Duration
+	packetTTL     time.Duration
+	now           func() time.Time
+
+	mu             sync.Mutex
+	identities     map[string]identity // pubkey -> observer row
+	dirtyObservers map[uuid.UUID]observerBump
+	knownBrokers   map[brokerKey]struct{}
+	dirtyBrokers   map[brokerKey]time.Time
+	knownIATAs     map[string]struct{}
+	packetsSeen    map[string]time.Time // hash -> last observation
+	dirtyPackets   map[string]time.Time
+}
+
+// New creates a Coalescer flushing every flushInterval. packetTTL controls
+// how long a quiet packet hash stays suppressed before a re-observation
+// writes through again.
+func New(store Store, flushInterval, packetTTL time.Duration) *Coalescer {
+	return &Coalescer{
+		Store:          store,
+		flushInterval:  flushInterval,
+		packetTTL:      packetTTL,
+		now:            time.Now,
+		identities:     make(map[string]identity),
+		dirtyObservers: make(map[uuid.UUID]observerBump),
+		knownBrokers:   make(map[brokerKey]struct{}),
+		dirtyBrokers:   make(map[brokerKey]time.Time),
+		knownIATAs:     make(map[string]struct{}),
+		packetsSeen:    make(map[string]time.Time),
+		dirtyPackets:   make(map[string]time.Time),
+	}
+}
+
+// UpsertObserver serves repeat lookups from the identity cache and records a
+// last_seen/observation_count bump instead of writing through.
+func (c *Coalescer) UpsertObserver(ctx context.Context, pubkey []byte) (uuid.UUID, string, error) {
+	key := string(pubkey)
+	c.mu.Lock()
+	if ident, ok := c.identities[key]; ok {
+		bump := c.dirtyObservers[ident.id]
+		bump.seen = c.now()
+		bump.count++
+		c.dirtyObservers[ident.id] = bump
+		c.mu.Unlock()
+		return ident.id, ident.name, nil
+	}
+	c.mu.Unlock()
+
+	id, name, err := c.Store.UpsertObserver(ctx, pubkey)
+	if err != nil {
+		return id, name, err
+	}
+	c.mu.Lock()
+	c.identities[key] = identity{id: id, name: name}
+	c.mu.Unlock()
+	return id, name, nil
+}
+
+// UpsertObserverBroker writes through the first time a pair is seen and
+// records a bump afterwards.
+func (c *Coalescer) UpsertObserverBroker(ctx context.Context, observerID uuid.UUID, brokerName string) error {
+	key := brokerKey{id: observerID, broker: brokerName}
+	c.mu.Lock()
+	if _, ok := c.knownBrokers[key]; ok {
+		c.dirtyBrokers[key] = c.now()
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+
+	if err := c.Store.UpsertObserverBroker(ctx, observerID, brokerName); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.knownBrokers[key] = struct{}{}
+	c.mu.Unlock()
+	return nil
+}
+
+// UpsertIATA only hits the store the first time each code shows up; the row
+// is insert-once so there is nothing to bump.
+func (c *Coalescer) UpsertIATA(ctx context.Context, iata string) error {
+	c.mu.Lock()
+	if _, ok := c.knownIATAs[iata]; ok {
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+
+	if err := c.Store.UpsertIATA(ctx, iata); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.knownIATAs[iata] = struct{}{}
+	c.mu.Unlock()
+	return nil
+}
+
+// UpsertPacket suppresses the last_heard_at bump for hashes seen recently and
+// records it for the next flush instead. Hashes with no re-observation within
+// packetTTL are forgotten, so the next occurrence writes through again.
+func (c *Coalescer) UpsertPacket(ctx context.Context, p ingest.UpsertPacketParams) (bool, error) {
+	key := string(p.PacketHash)
+	c.mu.Lock()
+	if _, ok := c.packetsSeen[key]; ok {
+		now := c.now()
+		c.packetsSeen[key] = now
+		c.dirtyPackets[key] = now
+		c.mu.Unlock()
+		return false, nil
+	}
+	c.mu.Unlock()
+
+	isNew, err := c.Store.UpsertPacket(ctx, p)
+	if err != nil {
+		return isNew, err
+	}
+	c.mu.Lock()
+	c.packetsSeen[key] = c.now()
+	c.mu.Unlock()
+	return isNew, nil
+}
+
+// UpdateObserverStatus passes through and drops the cached identity, since a
+// status message can set the display name returned by UpsertObserver.
+func (c *Coalescer) UpdateObserverStatus(ctx context.Context, p ingest.UpdateObserverStatusParams) (uuid.UUID, error) {
+	id, err := c.Store.UpdateObserverStatus(ctx, p)
+	if err == nil {
+		c.mu.Lock()
+		delete(c.identities, string(p.PublicKey))
+		c.mu.Unlock()
+	}
+	return id, err
+}
+
+// Run flushes on the configured interval until ctx is cancelled, then does a
+// final flush so a clean shutdown loses nothing.
+func (c *Coalescer) Run(ctx context.Context) {
+	ticker := time.NewTicker(c.flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.Flush(ctx)
+		case <-ctx.Done():
+			flushCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			c.Flush(flushCtx)
+			cancel()
+			return
+		}
+	}
+}
+
+// Flush writes all dirty presence state to the store in batched statements,
+// one per table. Failed batches are dropped rather than retried: presence
+// data self-heals on the next observation.
+func (c *Coalescer) Flush(ctx context.Context) {
+	c.mu.Lock()
+	observers := c.dirtyObservers
+	brokers := c.dirtyBrokers
+	packets := c.dirtyPackets
+	c.dirtyObservers = make(map[uuid.UUID]observerBump)
+	c.dirtyBrokers = make(map[brokerKey]time.Time)
+	c.dirtyPackets = make(map[string]time.Time)
+	cutoff := c.now().Add(-c.packetTTL)
+	for key, seen := range c.packetsSeen {
+		if seen.Before(cutoff) {
+			delete(c.packetsSeen, key)
+		}
+	}
+	c.mu.Unlock()
+
+	if len(observers) > 0 {
+		ids := make([]uuid.UUID, 0, len(observers))
+		seen := make([]time.Time, 0, len(observers))
+		counts := make([]int32, 0, len(observers))
+		for id, bump := range observers {
+			ids = append(ids, id)
+			seen = append(seen, bump.seen)
+			counts = append(counts, bump.count)
+		}
+		if err := c.Store.TouchObservers(ctx, ids, seen, counts); err != nil {
+			log.Printf("presence: flush observers failed (%d rows dropped): %v", len(ids), err)
+		}
+	}
+
+	if len(brokers) > 0 {
+		ids := make([]uuid.UUID, 0, len(brokers))
+		names := make([]string, 0, len(brokers))
+		seen := make([]time.Time, 0, len(brokers))
+		for key, ts := range brokers {
+			ids = append(ids, key.id)
+			names = append(names, key.broker)
+			seen = append(seen, ts)
+		}
+		if err := c.Store.TouchObserverBrokers(ctx, ids, names, seen); err != nil {
+			log.Printf("presence: flush observer brokers failed (%d rows dropped): %v", len(ids), err)
+		}
+	}
+
+	if len(packets) > 0 {
+		hashes := make([][]byte, 0, len(packets))
+		heard := make([]time.Time, 0, len(packets))
+		for key, ts := range packets {
+			hashes = append(hashes, []byte(key))
+			heard = append(heard, ts)
+		}
+		if err := c.Store.TouchPackets(ctx, hashes, heard); err != nil {
+			log.Printf("presence: flush packets failed (%d rows dropped): %v", len(hashes), err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #78

Presence bookkeeping (`observers`, `observer_brokers`, and packet re-observation bumps) was writing through to Postgres on every packet — roughly 400 single-row update transactions per second for `last_seen`-style fields that don't need per-packet precision. That churn is what drove the WAL amplification and vacuum load described in #78.

This takes the app-side approach suggested there:

- New `internal/presence` coalescer that accumulates observer, broker, and packet bumps in memory and flushes dirty rows on an interval, one batched statement per table per flush.
- Batched touch queries in the db layer to support those flushes.
- New config under `presence:` — `flush_interval` (default 30s) and `packet_ttl` (default 30s, how long a quiet packet stays coalesced before writing through again). Both documented in the README.
- Beacon ingest now routes presence updates through the coalescer instead of writing directly.

An unclean shutdown loses at most one flush interval of presence freshness, which is the same durability trade we were previously buying with `synchronous_commit=off` — except now the row-version churn is gone too, so the vacuum treadmill and CPU cost go with it, and a stock-compose redeploy can't silently regress it.

The path-hash planning fix from the same investigation is split out separately since it's independent (#81).