### PR TITLE
2. Split path hash resolution into per-width queries

### DIFF
--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -928,19 +928,41 @@ ORDER BY nn.last_seen DESC;
 -- HELPERS
 -- ============================================================
 
--- name: ResolvePathHashes :many
+-- Path hash resolution is split per prefix width so each query gets a
+-- cacheable generic plan on its (iata, prefix_N) index; a single CASE
+-- predicate forced a fresh custom plan on every call.
+
+-- name: ResolvePathHashesP1 :many
 SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
 FROM node_short_ids ns
 JOIN nodes n ON n.id = ns.node_id
 WHERE ns.iata = $1
   AND n.node_type IN (2, 3)
-  AND CASE
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 1 THEN ns.prefix_1 = ANY($2)
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 2 THEN ns.prefix_2 = ANY($2)
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 3 THEN ns.prefix_3 = ANY($2)
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 4 THEN ns.prefix_4 = ANY($2)
-    ELSE FALSE
-  END;
+  AND ns.prefix_1 = ANY($2::bytea[]);
+
+-- name: ResolvePathHashesP2 :many
+SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+JOIN nodes n ON n.id = ns.node_id
+WHERE ns.iata = $1
+  AND n.node_type IN (2, 3)
+  AND ns.prefix_2 = ANY($2::bytea[]);
+
+-- name: ResolvePathHashesP3 :many
+SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+JOIN nodes n ON n.id = ns.node_id
+WHERE ns.iata = $1
+  AND n.node_type IN (2, 3)
+  AND ns.prefix_3 = ANY($2::bytea[]);
+
+-- name: ResolvePathHashesP4 :many
+SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+JOIN nodes n ON n.id = ns.node_id
+WHERE ns.iata = $1
+  AND n.node_type IN (2, 3)
+  AND ns.prefix_4 = ANY($2::bytea[]);
 
 -- name: RefreshHourlyStats :exec
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_hourly_iata_stats;

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -950,19 +950,64 @@ func (mr *MockQuerierMockRecorder) RefreshTopNodes(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTopNodes", reflect.TypeOf((*MockQuerier)(nil).RefreshTopNodes), ctx)
 }
 
-// ResolvePathHashes mocks base method.
-func (m *MockQuerier) ResolvePathHashes(ctx context.Context, arg db.ResolvePathHashesParams) ([]db.ResolvePathHashesRow, error) {
+// ResolvePathHashesP1 mocks base method.
+func (m *MockQuerier) ResolvePathHashesP1(ctx context.Context, arg db.ResolvePathHashesP1Params) ([]db.ResolvePathHashesP1Row, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolvePathHashes", ctx, arg)
-	ret0, _ := ret[0].([]db.ResolvePathHashesRow)
+	ret := m.ctrl.Call(m, "ResolvePathHashesP1", ctx, arg)
+	ret0, _ := ret[0].([]db.ResolvePathHashesP1Row)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ResolvePathHashes indicates an expected call of ResolvePathHashes.
-func (mr *MockQuerierMockRecorder) ResolvePathHashes(ctx, arg any) *gomock.Call {
+// ResolvePathHashesP1 indicates an expected call of ResolvePathHashesP1.
+func (mr *MockQuerierMockRecorder) ResolvePathHashesP1(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePathHashes", reflect.TypeOf((*MockQuerier)(nil).ResolvePathHashes), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePathHashesP1", reflect.TypeOf((*MockQuerier)(nil).ResolvePathHashesP1), ctx, arg)
+}
+
+// ResolvePathHashesP2 mocks base method.
+func (m *MockQuerier) ResolvePathHashesP2(ctx context.Context, arg db.ResolvePathHashesP2Params) ([]db.ResolvePathHashesP2Row, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolvePathHashesP2", ctx, arg)
+	ret0, _ := ret[0].([]db.ResolvePathHashesP2Row)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolvePathHashesP2 indicates an expected call of ResolvePathHashesP2.
+func (mr *MockQuerierMockRecorder) ResolvePathHashesP2(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePathHashesP2", reflect.TypeOf((*MockQuerier)(nil).ResolvePathHashesP2), ctx, arg)
+}
+
+// ResolvePathHashesP3 mocks base method.
+func (m *MockQuerier) ResolvePathHashesP3(ctx context.Context, arg db.ResolvePathHashesP3Params) ([]db.ResolvePathHashesP3Row, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolvePathHashesP3", ctx, arg)
+	ret0, _ := ret[0].([]db.ResolvePathHashesP3Row)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolvePathHashesP3 indicates an expected call of ResolvePathHashesP3.
+func (mr *MockQuerierMockRecorder) ResolvePathHashesP3(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePathHashesP3", reflect.TypeOf((*MockQuerier)(nil).ResolvePathHashesP3), ctx, arg)
+}
+
+// ResolvePathHashesP4 mocks base method.
+func (m *MockQuerier) ResolvePathHashesP4(ctx context.Context, arg db.ResolvePathHashesP4Params) ([]db.ResolvePathHashesP4Row, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolvePathHashesP4", ctx, arg)
+	ret0, _ := ret[0].([]db.ResolvePathHashesP4Row)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolvePathHashesP4 indicates an expected call of ResolvePathHashesP4.
+func (mr *MockQuerierMockRecorder) ResolvePathHashesP4(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePathHashesP4", reflect.TypeOf((*MockQuerier)(nil).ResolvePathHashesP4), ctx, arg)
 }
 
 // SearchKnownRoutes mocks base method.

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -132,7 +132,13 @@ type Querier interface {
 	// ============================================================
 	// HELPERS
 	// ============================================================
-	ResolvePathHashes(ctx context.Context, arg ResolvePathHashesParams) ([]ResolvePathHashesRow, error)
+	// Path hash resolution is split per prefix width so each query gets a
+	// cacheable generic plan on its (iata, prefix_N) index; a single CASE
+	// predicate forced a fresh custom plan on every call.
+	ResolvePathHashesP1(ctx context.Context, arg ResolvePathHashesP1Params) ([]ResolvePathHashesP1Row, error)
+	ResolvePathHashesP2(ctx context.Context, arg ResolvePathHashesP2Params) ([]ResolvePathHashesP2Row, error)
+	ResolvePathHashesP3(ctx context.Context, arg ResolvePathHashesP3Params) ([]ResolvePathHashesP3Row, error)
+	ResolvePathHashesP4(ctx context.Context, arg ResolvePathHashesP4Params) ([]ResolvePathHashesP4Row, error)
 	// Returns known routes containing a subsequence from source to destination hash prefix.
 	// Verifies source appears before destination in the route.
 	SearchKnownRoutes(ctx context.Context, arg SearchKnownRoutesParams) ([]KnownRoute, error)

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -2809,28 +2809,23 @@ func (q *Queries) RefreshTopNodes(ctx context.Context) error {
 	return err
 }
 
-const resolvePathHashes = `-- name: ResolvePathHashes :many
+const resolvePathHashesP1 = `-- name: ResolvePathHashesP1 :many
+
 
 SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
 FROM node_short_ids ns
 JOIN nodes n ON n.id = ns.node_id
 WHERE ns.iata = $1
   AND n.node_type IN (2, 3)
-  AND CASE
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 1 THEN ns.prefix_1 = ANY($2)
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 2 THEN ns.prefix_2 = ANY($2)
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 3 THEN ns.prefix_3 = ANY($2)
-    WHEN cardinality($2::bytea[]) > 0 AND length($2[1]) = 4 THEN ns.prefix_4 = ANY($2)
-    ELSE FALSE
-  END
+  AND ns.prefix_1 = ANY($2::bytea[])
 `
 
-type ResolvePathHashesParams struct {
+type ResolvePathHashesP1Params struct {
 	Iata    string   `json:"iata"`
 	Column2 [][]byte `json:"column_2"`
 }
 
-type ResolvePathHashesRow struct {
+type ResolvePathHashesP1Row struct {
 	Hash      []byte    `json:"hash"`
 	NodeID    uuid.UUID `json:"node_id"`
 	Name      *string   `json:"name"`
@@ -2842,15 +2837,168 @@ type ResolvePathHashesRow struct {
 // ============================================================
 // HELPERS
 // ============================================================
-func (q *Queries) ResolvePathHashes(ctx context.Context, arg ResolvePathHashesParams) ([]ResolvePathHashesRow, error) {
-	rows, err := q.db.Query(ctx, resolvePathHashes, arg.Iata, arg.Column2)
+// Path hash resolution is split per prefix width so each query gets a
+// cacheable generic plan on its (iata, prefix_N) index; a single CASE
+// predicate forced a fresh custom plan on every call.
+func (q *Queries) ResolvePathHashesP1(ctx context.Context, arg ResolvePathHashesP1Params) ([]ResolvePathHashesP1Row, error) {
+	rows, err := q.db.Query(ctx, resolvePathHashesP1, arg.Iata, arg.Column2)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ResolvePathHashesRow{}
+	items := []ResolvePathHashesP1Row{}
 	for rows.Next() {
-		var i ResolvePathHashesRow
+		var i ResolvePathHashesP1Row
+		if err := rows.Scan(
+			&i.Hash,
+			&i.NodeID,
+			&i.Name,
+			&i.Latitude,
+			&i.Longitude,
+			&i.PublicKey,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const resolvePathHashesP2 = `-- name: ResolvePathHashesP2 :many
+SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+JOIN nodes n ON n.id = ns.node_id
+WHERE ns.iata = $1
+  AND n.node_type IN (2, 3)
+  AND ns.prefix_2 = ANY($2::bytea[])
+`
+
+type ResolvePathHashesP2Params struct {
+	Iata    string   `json:"iata"`
+	Column2 [][]byte `json:"column_2"`
+}
+
+type ResolvePathHashesP2Row struct {
+	Hash      []byte    `json:"hash"`
+	NodeID    uuid.UUID `json:"node_id"`
+	Name      *string   `json:"name"`
+	Latitude  *float64  `json:"latitude"`
+	Longitude *float64  `json:"longitude"`
+	PublicKey []byte    `json:"public_key"`
+}
+
+func (q *Queries) ResolvePathHashesP2(ctx context.Context, arg ResolvePathHashesP2Params) ([]ResolvePathHashesP2Row, error) {
+	rows, err := q.db.Query(ctx, resolvePathHashesP2, arg.Iata, arg.Column2)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ResolvePathHashesP2Row{}
+	for rows.Next() {
+		var i ResolvePathHashesP2Row
+		if err := rows.Scan(
+			&i.Hash,
+			&i.NodeID,
+			&i.Name,
+			&i.Latitude,
+			&i.Longitude,
+			&i.PublicKey,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const resolvePathHashesP3 = `-- name: ResolvePathHashesP3 :many
+SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+JOIN nodes n ON n.id = ns.node_id
+WHERE ns.iata = $1
+  AND n.node_type IN (2, 3)
+  AND ns.prefix_3 = ANY($2::bytea[])
+`
+
+type ResolvePathHashesP3Params struct {
+	Iata    string   `json:"iata"`
+	Column2 [][]byte `json:"column_2"`
+}
+
+type ResolvePathHashesP3Row struct {
+	Hash      []byte    `json:"hash"`
+	NodeID    uuid.UUID `json:"node_id"`
+	Name      *string   `json:"name"`
+	Latitude  *float64  `json:"latitude"`
+	Longitude *float64  `json:"longitude"`
+	PublicKey []byte    `json:"public_key"`
+}
+
+func (q *Queries) ResolvePathHashesP3(ctx context.Context, arg ResolvePathHashesP3Params) ([]ResolvePathHashesP3Row, error) {
+	rows, err := q.db.Query(ctx, resolvePathHashesP3, arg.Iata, arg.Column2)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ResolvePathHashesP3Row{}
+	for rows.Next() {
+		var i ResolvePathHashesP3Row
+		if err := rows.Scan(
+			&i.Hash,
+			&i.NodeID,
+			&i.Name,
+			&i.Latitude,
+			&i.Longitude,
+			&i.PublicKey,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const resolvePathHashesP4 = `-- name: ResolvePathHashesP4 :many
+SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+JOIN nodes n ON n.id = ns.node_id
+WHERE ns.iata = $1
+  AND n.node_type IN (2, 3)
+  AND ns.prefix_4 = ANY($2::bytea[])
+`
+
+type ResolvePathHashesP4Params struct {
+	Iata    string   `json:"iata"`
+	Column2 [][]byte `json:"column_2"`
+}
+
+type ResolvePathHashesP4Row struct {
+	Hash      []byte    `json:"hash"`
+	NodeID    uuid.UUID `json:"node_id"`
+	Name      *string   `json:"name"`
+	Latitude  *float64  `json:"latitude"`
+	Longitude *float64  `json:"longitude"`
+	PublicKey []byte    `json:"public_key"`
+}
+
+func (q *Queries) ResolvePathHashesP4(ctx context.Context, arg ResolvePathHashesP4Params) ([]ResolvePathHashesP4Row, error) {
+	rows, err := q.db.Query(ctx, resolvePathHashesP4, arg.Iata, arg.Column2)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ResolvePathHashesP4Row{}
+	for rows.Next() {
+		var i ResolvePathHashesP4Row
 		if err := rows.Scan(
 			&i.Hash,
 			&i.NodeID,

--- a/db/store.go
+++ b/db/store.go
@@ -32,10 +32,33 @@ func (s *Store) ResolvePathHashes(ctx context.Context, iata string, hashes [][]b
 	if len(hashes) == 0 {
 		return nil, nil
 	}
-	rows, err := s.q.ResolvePathHashes(ctx, sqlc.ResolvePathHashesParams{
-		Iata:    iata,
-		Column2: hashes,
-	})
+	// One query per prefix width; the row shapes are identical.
+	var rows []sqlc.ResolvePathHashesP4Row
+	var err error
+	switch len(hashes[0]) {
+	case 1:
+		var rs []sqlc.ResolvePathHashesP1Row
+		rs, err = s.q.ResolvePathHashesP1(ctx, sqlc.ResolvePathHashesP1Params{Iata: iata, Column2: hashes})
+		for _, r := range rs {
+			rows = append(rows, sqlc.ResolvePathHashesP4Row(r))
+		}
+	case 2:
+		var rs []sqlc.ResolvePathHashesP2Row
+		rs, err = s.q.ResolvePathHashesP2(ctx, sqlc.ResolvePathHashesP2Params{Iata: iata, Column2: hashes})
+		for _, r := range rs {
+			rows = append(rows, sqlc.ResolvePathHashesP4Row(r))
+		}
+	case 3:
+		var rs []sqlc.ResolvePathHashesP3Row
+		rs, err = s.q.ResolvePathHashesP3(ctx, sqlc.ResolvePathHashesP3Params{Iata: iata, Column2: hashes})
+		for _, r := range rs {
+			rows = append(rows, sqlc.ResolvePathHashesP4Row(r))
+		}
+	case 4:
+		rows, err = s.q.ResolvePathHashesP4(ctx, sqlc.ResolvePathHashesP4Params{Iata: iata, Column2: hashes})
+	default:
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/db/store_test.go
+++ b/db/store_test.go
@@ -116,7 +116,7 @@ func TestResolvePathHashes_DBError(t *testing.T) {
 
 	hashes := [][]byte{{0x01, 0x02}}
 	mock.EXPECT().
-		ResolvePathHashes(gomock.Any(), sqlc.ResolvePathHashesParams{
+		ResolvePathHashesP2(gomock.Any(), sqlc.ResolvePathHashesP2Params{
 			Iata:    "YVR",
 			Column2: hashes,
 		}).
@@ -144,11 +144,11 @@ func TestResolvePathHashes_Mapping(t *testing.T) {
 	hashes := [][]byte{{0xab, 0xcd}}
 
 	mock.EXPECT().
-		ResolvePathHashes(gomock.Any(), sqlc.ResolvePathHashesParams{
+		ResolvePathHashesP2(gomock.Any(), sqlc.ResolvePathHashesP2Params{
 			Iata:    "YVR",
 			Column2: hashes,
 		}).
-		Return([]sqlc.ResolvePathHashesRow{
+		Return([]sqlc.ResolvePathHashesP2Row{
 			{
 				Hash:      []byte{0xab, 0xcd},
 				NodeID:    nodeID,

--- a/db/traces_test.go
+++ b/db/traces_test.go
@@ -122,11 +122,11 @@ func TestGetTraceByTag_WithPacket(t *testing.T) {
 		}, nil)
 
 	mock.EXPECT().
-		ResolvePathHashes(gomock.Any(), sqlc.ResolvePathHashesParams{
+		ResolvePathHashesP2(gomock.Any(), sqlc.ResolvePathHashesP2Params{
 			Iata:    "YVR",
 			Column2: [][]byte{{0xaa, 0xbb}},
 		}).
-		Return([]sqlc.ResolvePathHashesRow{}, nil)
+		Return([]sqlc.ResolvePathHashesP2Row{}, nil)
 
 	store := &Store{q: mock}
 	detail, err := store.GetTraceByTag(context.Background(), "trace-001")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MeshCore-Beacon/beacon-server
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
Closes #81

`ResolvePathHashes` used a `CASE WHEN length($2[1]) = ...` predicate to pick the prefix column at runtime, which blocks generic plan caching — Postgres replanned every execution, and with the query running per observation plus the WS resolved-path flow, planning (~0.9ms) was costing more than execution (~0.1–0.5ms) and topping pg_stat_activity samples during normal ingest.

Since the caller already knows the hash width, this splits the query into per-width variants (`prefix_N = ANY($2)`), each of which gets a cached plan against its existing `(iata, prefix_N)` index. No behavior change.

Cherry-picked from the performance branch so it lands independently of the presence coalescing work in #82.