### PR TITLE
3. Index packets by last_heard_at and drive IATA-filtered lists from the observation index

### DIFF
--- a/db/channels.go
+++ b/db/channels.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"strings"
 	"time"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
@@ -132,11 +131,10 @@ func (s *Store) ListChannelMessages(ctx context.Context, channelID *int32, since
 	ts := pgtype.Timestamptz{Time: since, Valid: !since.IsZero()}
 	var messages []api.ChannelMessage
 	var hasMore bool
-	iataFilter := strings.Join(iatas, ",")
 	if channelID == nil {
 		rows, err := s.q.ListAllChannelMessages(ctx, sqlc.ListAllChannelMessagesParams{
 			Column1: ts,
-			Column2: iataFilter,
+			Column2: iatas,
 			Column3: scope,
 			Column4: cursor,
 			Limit:   limit + 1,
@@ -156,7 +154,7 @@ func (s *Store) ListChannelMessages(ctx context.Context, channelID *int32, since
 		rows, err := s.q.ListChannelMessages(ctx, sqlc.ListChannelMessagesParams{
 			ChannelID: *channelID,
 			Column2:   ts,
-			Column3:   iataFilter,
+			Column3:   iatas,
 			Column4:   scope,
 			Column5:   cursor,
 			Limit:     limit + 1,
@@ -187,11 +185,10 @@ func (s *Store) ListChannelMessages(ctx context.Context, channelID *int32, since
 }
 
 func (s *Store) ListChannelMessagesByHash(ctx context.Context, hash []byte, since time.Time, limit int32, iatas []string, scope string, cursor int64) (api.Page[api.ChannelMessage], error) {
-	iataFilter := strings.Join(iatas, ",")
 	rows, err := s.q.ListChannelMessagesByHash(ctx, sqlc.ListChannelMessagesByHashParams{
 		ChannelHash: hash,
 		Column2:     pgtype.Timestamptz{Time: since, Valid: !since.IsZero()},
-		Column3:     iataFilter,
+		Column3:     iatas,
 		Column4:     scope,
 		Column5:     cursor,
 		Limit:       limit + 1,
@@ -220,10 +217,9 @@ func (s *Store) ListChannelMessagesByHash(ctx context.Context, hash []byte, sinc
 }
 
 func (s *Store) ListMessagesAfterID(ctx context.Context, afterID int64, iatas []string, scope string, limit int32) ([]api.ChannelMessage, error) {
-	iataFilter := strings.Join(iatas, ",")
 	rows, err := s.q.ListMessagesAfterID(ctx, sqlc.ListMessagesAfterIDParams{
 		ID:      afterID,
-		Column2: iataFilter,
+		Column2: iatas,
 		Column3: scope,
 		Limit:   limit,
 	})

--- a/db/channels_test.go
+++ b/db/channels_test.go
@@ -199,7 +199,7 @@ func TestListChannelMessages_AllChannels(t *testing.T) {
 	mock.EXPECT().
 		ListAllChannelMessages(gomock.Any(), sqlc.ListAllChannelMessagesParams{
 			Column1: pgtype.Timestamptz{},
-			Column2: "YVR",
+			Column2: []string{"YVR"},
 			Column3: "",
 			Column4: int64(0),
 			Limit:   3,
@@ -263,7 +263,7 @@ func TestListChannelMessages_ByChannelID(t *testing.T) {
 		ListChannelMessages(gomock.Any(), sqlc.ListChannelMessagesParams{
 			ChannelID: channelID,
 			Column2:   pgtype.Timestamptz{},
-			Column3:   "YVR",
+			Column3:   []string{"YVR"},
 			Column4:   "",
 			Column5:   int64(0),
 			Limit:     3,

--- a/db/migrations/008_packets_last_heard_index.sql
+++ b/db/migrations/008_packets_last_heard_index.sql
@@ -1,0 +1,8 @@
+-- 008_packets_last_heard_index.sql
+--
+-- The packet list orders by last_heard_at but there was no index on it, so
+-- every page seq-scanned and sorted all packets (~2.8s per page on a 1.5M
+-- row table; 31ms with the index). Affordable to maintain now that presence
+-- coalescing keeps this column from being rewritten on every observation.
+
+CREATE INDEX idx_packets_last_heard ON packets(last_heard_at DESC);

--- a/db/nodes.go
+++ b/db/nodes.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
@@ -85,10 +84,9 @@ func (s *Store) ListNodes(ctx context.Context, nodeType int16, iatas []string, s
 	if cursor > 0 {
 		cursorTS = pgtype.Timestamptz{Time: time.UnixMilli(cursor), Valid: true}
 	}
-	iataFilter := strings.Join(iatas, ",")
 	rows, err := s.q.ListNodes(ctx, sqlc.ListNodesParams{
 		Column1:  nodeType,
-		Column2:  iataFilter,
+		Column2:  iatas,
 		Column3:  tristate(supportsMultibytePaths),
 		Column4:  tristate(supportsMultibyteTraces),
 		Column5:  pubkey,

--- a/db/nodes_test.go
+++ b/db/nodes_test.go
@@ -379,7 +379,7 @@ func TestListNodes_IncludeNeighbors_PassesFlagAndMapsIDs(t *testing.T) {
 
 	mock.EXPECT().
 		ListNodes(gomock.Any(), gomock.Eq(sqlc.ListNodesParams{
-			Column1: int16(0), Column2: "", Column3: "any", Column4: "any",
+			Column1: int16(0), Column2: nil, Column3: "any", Column4: "any",
 			Column5: nil, Column6: "", Column7: pgtype.Timestamptz{},
 			Limit: 11, Column9: "", Column10: true,
 		})).
@@ -409,7 +409,7 @@ func TestListNodes_ExcludeNeighbors_LeavesIDsNil(t *testing.T) {
 
 	mock.EXPECT().
 		ListNodes(gomock.Any(), gomock.Eq(sqlc.ListNodesParams{
-			Column1: int16(0), Column2: "", Column3: "any", Column4: "any",
+			Column1: int16(0), Column2: nil, Column3: "any", Column4: "any",
 			Column5: nil, Column6: "", Column7: pgtype.Timestamptz{},
 			Limit: 11, Column9: "", Column10: false,
 		})).

--- a/db/observers.go
+++ b/db/observers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
@@ -35,9 +34,8 @@ func (s *Store) ListObservers(ctx context.Context, iatas []string, observerType,
 	if cursor > 0 {
 		cursorTS = pgtype.Timestamptz{Time: time.UnixMilli(cursor), Valid: true}
 	}
-	iataFilter := strings.Join(iatas, ",")
 	params := sqlc.ListObserversParams{
-		Column1: iataFilter,
+		Column1: iatas,
 		Column2: observerType,
 		Column3: broker,
 		Column4: status,

--- a/db/packets.go
+++ b/db/packets.go
@@ -59,6 +59,9 @@ func (s *Store) SetPacketDecrypted(ctx context.Context, hash []byte) error {
 }
 
 func (s *Store) ListPackets(ctx context.Context, payloadType, routeType int16, iatas []string, scope string, since, until time.Time, cursor int64, limit int32) (api.Page[api.PacketSummary], error) {
+	if len(iatas) > 0 {
+		return s.listPacketsByIATAs(ctx, payloadType, routeType, iatas, scope, since, until, cursor, limit)
+	}
 	var cursorTS pgtype.Timestamptz
 	if cursor > 0 {
 		cursorTS = pgtype.Timestamptz{Time: time.UnixMilli(cursor), Valid: true}
@@ -74,12 +77,11 @@ func (s *Store) ListPackets(ctx context.Context, payloadType, routeType int16, i
 	rows, err := s.q.ListPackets(ctx, sqlc.ListPacketsParams{
 		Column1: payloadType,
 		Column2: routeType,
-		Column3: iatas,
-		Column4: sinceTS,
-		Column5: untilTS,
-		Column6: cursorTS,
+		Column3: sinceTS,
+		Column4: untilTS,
+		Column5: cursorTS,
 		Limit:   limit + 1,
-		Column8: scope,
+		Column7: scope,
 	})
 	if err != nil {
 		return api.Page[api.PacketSummary]{}, err
@@ -113,6 +115,75 @@ func (s *Store) ListPackets(ctx context.Context, payloadType, routeType int16, i
 	var nextCursor *int64
 	if hasMore && len(items) > 0 {
 		last := items[len(items)-1].LastHeardAt
+		nextCursor = &last
+	}
+	return api.Page[api.PacketSummary]{
+		Items:      items,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}
+
+func (s *Store) listPacketsByIATAs(ctx context.Context, payloadType, routeType int16, iatas []string, scope string, since, until time.Time, cursor int64, limit int32) (api.Page[api.PacketSummary], error) {
+	var cursorTS pgtype.Timestamptz
+	if cursor > 0 {
+		cursorTS = pgtype.Timestamptz{Time: time.UnixMilli(cursor), Valid: true}
+	}
+	var sinceTS pgtype.Timestamptz
+	if !since.IsZero() {
+		sinceTS = pgtype.Timestamptz{Time: since, Valid: true}
+	}
+	var untilTS pgtype.Timestamptz
+	if !until.IsZero() {
+		untilTS = pgtype.Timestamptz{Time: until, Valid: true}
+	}
+	// A packet appears once per observer that heard it at a site
+	// ((packet_hash, observer_id) is unique), so scan deep enough per site
+	// to still fill the page after collapsing those duplicates.
+	rows, err := s.q.ListPacketsByIATAs(ctx, sqlc.ListPacketsByIATAsParams{
+		Iatas:       iatas,
+		ScanDepth:   (limit + 1) * 8,
+		CursorTs:    cursorTS,
+		PayloadType: payloadType,
+		RouteType:   routeType,
+		SinceTs:     sinceTS,
+		UntilTs:     untilTS,
+		ScopeName:   scope,
+		PageLimit:   limit + 1,
+	})
+	if err != nil {
+		return api.Page[api.PacketSummary]{}, err
+	}
+	hasMore := len(rows) > int(limit)
+	if hasMore {
+		rows = rows[:limit]
+	}
+	items := make([]api.PacketSummary, 0, len(rows))
+	for _, v := range rows {
+		item := api.PacketSummary{
+			PacketHash:       hex.EncodeToString(v.PacketHash),
+			PayloadType:      v.PayloadType,
+			PayloadTypeName:  api.PayloadTypeName(v.PayloadType),
+			RouteType:        v.RouteType,
+			RouteTypeName:    api.RouteTypeName(v.RouteType),
+			Scope:            v.ScopeName,
+			FirstHeardAt:     v.FirstHeardAt.Time.UnixMilli(),
+			LastHeardAt:      v.LastHeardAt.Time.UnixMilli(),
+			ObservationCount: int32(v.ObservationCount),
+		}
+		if v.LatestObserverID != (uuid.UUID{}) {
+			item.LatestObserver = &api.PacketLatestObserver{
+				ID:          v.LatestObserverID,
+				DisplayName: v.LatestObserverName,
+				IATA:        v.LatestObserverIata,
+			}
+		}
+		items = append(items, item)
+	}
+	// Cursor follows site-local recency, not the packet's global last_heard_at.
+	var nextCursor *int64
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1].SiteHeardAt.Time.UnixMilli()
 		nextCursor = &last
 	}
 	return api.Page[api.PacketSummary]{

--- a/db/packets.go
+++ b/db/packets.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
@@ -72,11 +71,10 @@ func (s *Store) ListPackets(ctx context.Context, payloadType, routeType int16, i
 	if !until.IsZero() {
 		untilTS = pgtype.Timestamptz{Time: until, Valid: true}
 	}
-	iataFilter := strings.Join(iatas, ",")
 	rows, err := s.q.ListPackets(ctx, sqlc.ListPacketsParams{
 		Column1: payloadType,
 		Column2: routeType,
-		Column3: iataFilter,
+		Column3: iatas,
 		Column4: sinceTS,
 		Column5: untilTS,
 		Column6: cursorTS,
@@ -125,12 +123,11 @@ func (s *Store) ListPackets(ctx context.Context, payloadType, routeType int16, i
 }
 
 func (s *Store) ListPacketsAfterID(ctx context.Context, afterObservationID int64, payloadType, routeType int16, iatas []string, scope string, limit int32) ([]api.PacketSummary, error) {
-	iataFilter := strings.Join(iatas, ",")
 	rows, err := s.q.ListPacketsAfterID(ctx, sqlc.ListPacketsAfterIDParams{
 		ID:      afterObservationID,
 		Column2: payloadType,
 		Column3: routeType,
-		Column4: iataFilter,
+		Column4: iatas,
 		Column5: scope,
 		Limit:   limit,
 	})

--- a/db/packets_test.go
+++ b/db/packets_test.go
@@ -386,3 +386,66 @@ func TestListNodeObservations_Pagination(t *testing.T) {
 		t.Error("expected NextCursor to be set")
 	}
 }
+
+func TestListPackets_IATAFilterRoutesToObservationIndex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mockdb.NewMockQuerier(ctrl)
+
+	siteHeard := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	globalHeard := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+
+	// limit=1 with 2 rows returned exercises the +1 trick and the trim.
+	mock.EXPECT().
+		ListPacketsByIATAs(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, p sqlc.ListPacketsByIATAsParams) ([]sqlc.ListPacketsByIATAsRow, error) {
+			if len(p.Iatas) != 1 || p.Iatas[0] != "ALF" {
+				t.Errorf("iatas param = %v, want [ALF]", p.Iatas)
+			}
+			if p.PageLimit != 2 { // limit+1
+				t.Errorf("page limit = %d, want 2", p.PageLimit)
+			}
+			if p.ScanDepth != 16 { // (limit+1)*8
+				t.Errorf("scan depth = %d, want 16", p.ScanDepth)
+			}
+			return []sqlc.ListPacketsByIATAsRow{
+				{
+					PacketHash:  []byte{0x01},
+					LastHeardAt: pgtype.Timestamptz{Time: globalHeard, Valid: true},
+					SiteHeardAt: pgtype.Timestamptz{Time: siteHeard, Valid: true},
+				},
+				{
+					PacketHash:  []byte{0x02},
+					LastHeardAt: pgtype.Timestamptz{Time: globalHeard, Valid: true},
+					SiteHeardAt: pgtype.Timestamptz{Time: siteHeard.Add(-time.Hour), Valid: true},
+				},
+			}, nil
+		})
+
+	store := &Store{q: mock}
+	page, err := store.ListPackets(context.Background(), -1, -1, []string{"ALF"}, "", time.Time{}, time.Time{}, 0, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Items) != 1 || !page.HasMore {
+		t.Fatalf("got %d items hasMore=%v, want 1 item hasMore=true", len(page.Items), page.HasMore)
+	}
+	// Cursor must follow site-local recency, not the packet's global last_heard_at.
+	if page.NextCursor == nil || *page.NextCursor != siteHeard.UnixMilli() {
+		t.Errorf("next cursor = %v, want %d (site heard_at)", page.NextCursor, siteHeard.UnixMilli())
+	}
+}
+
+func TestListPackets_UnfilteredKeepsGlobalQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mockdb.NewMockQuerier(ctrl)
+
+	// gomock is strict: an unexpected ListPacketsByIATAs call fails the test.
+	mock.EXPECT().
+		ListPackets(gomock.Any(), gomock.Any()).
+		Return([]sqlc.ListPacketsRow{}, nil)
+
+	store := &Store{q: mock}
+	if _, err := store.ListPackets(context.Background(), -1, -1, nil, "", time.Time{}, time.Time{}, 0, 50); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/db/packets_test.go
+++ b/db/packets_test.go
@@ -330,6 +330,28 @@ func TestGetPacket_FirstToLastMs(t *testing.T) {
 	}
 }
 
+func TestListPacketsAfterID_PassesIATAsAsArray(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mockdb.NewMockQuerier(ctrl)
+
+	mock.EXPECT().
+		ListPacketsAfterID(gomock.Any(), sqlc.ListPacketsAfterIDParams{
+			ID:      0,
+			Column2: int16(-1),
+			Column3: int16(-1),
+			Column4: []string{"ALF", "YYZ"},
+			Column5: "",
+			Limit:   50,
+		}).
+		Return([]sqlc.ListPacketsAfterIDRow{}, nil)
+
+	store := &Store{q: mock}
+	_, err := store.ListPacketsAfterID(context.Background(), 0, -1, -1, []string{"ALF", "YYZ"}, "", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestListNodeObservations_Pagination(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := mockdb.NewMockQuerier(ctrl)

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -332,7 +332,8 @@ SELECT COUNT(*) FROM packet_observations WHERE packet_hash = $1;
 
 -- name: ListPackets :many
 -- Returns packets with the latest observation rolled in for display.
--- Pass cursor=0 to start from the beginning.
+-- Pass cursor=0 to start from the beginning. IATA-filtered requests are
+-- served by ListPacketsByIATAs instead.
 SELECT
   p.packet_hash,
   p.payload_type,
@@ -358,17 +359,75 @@ LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE
   ($1::smallint = -1 OR p.payload_type = $1::smallint)
   AND ($2::smallint = -1 OR p.route_type = $2::smallint)
-  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR EXISTS (
-      SELECT 1 FROM packet_observations po3
-      WHERE po3.packet_hash = p.packet_hash
-      AND po3.iata = ANY($3::bpchar[])
-  ))
-  AND ($4::timestamptz IS NULL OR p.first_heard_at >= $4)
-  AND ($5::timestamptz IS NULL OR p.first_heard_at <= $5)
-  AND ($6::timestamptz IS NULL OR p.last_heard_at < $6)
-  AND ($8::text = '' OR ts.name = $8::text)
+  AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
+  AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
+  AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
+  AND ($7::text = '' OR ts.name = $7::text)
 ORDER BY p.last_heard_at DESC
-LIMIT $7;
+LIMIT $6;
+
+-- name: ListPacketsByIATAs :many
+-- IATA-filtered packet list, driven from idx_observations_iata_heard.
+-- Walking packets newest-first and probing for the site probes ~589k packets
+-- to fill a page for a quiet site; walking the site's own observation log is
+-- proportional to the page size instead. Results are ordered by when the
+-- requested sites heard the packet (site-local recency) and the cursor
+-- follows that ordering. scan_depth is a multiple of the page size to
+-- absorb per-observer duplicates; if duplication exceeds it across a
+-- page, pagination ends early (hasMore=false) rather than returning a
+-- short page, even though deeper matches exist.
+SELECT
+  p.packet_hash,
+  p.payload_type,
+  p.route_type,
+  p.first_heard_at,
+  p.last_heard_at,
+  p.scope_id,
+  ts.name AS scope_name,
+  sh.site_heard_at,
+  (SELECT COUNT(*) FROM packet_observations po2 WHERE po2.packet_hash = p.packet_hash) AS observation_count,
+  po.observer_id AS latest_observer_id,
+  o.display_name AS latest_observer_name,
+  po.iata AS latest_observer_iata
+FROM (
+  SELECT hits.packet_hash, MAX(hits.heard_at)::timestamptz AS site_heard_at
+  FROM unnest(@iatas::bpchar[]) AS req(iata)
+  CROSS JOIN LATERAL (
+    SELECT po3.packet_hash, po3.heard_at
+    FROM packet_observations po3
+    JOIN packets p2 ON p2.packet_hash = po3.packet_hash
+    WHERE po3.iata = req.iata
+      AND po3.heard_at < COALESCE(@cursor_ts::timestamptz, 'infinity'::timestamptz)
+      AND (@payload_type::smallint = -1 OR p2.payload_type = @payload_type::smallint)
+      AND (@route_type::smallint = -1 OR p2.route_type = @route_type::smallint)
+      AND (@since_ts::timestamptz IS NULL OR p2.first_heard_at >= @since_ts)
+      AND (@until_ts::timestamptz IS NULL OR p2.first_heard_at <= @until_ts)
+      AND (@scope_name::text = '' OR EXISTS (
+        SELECT 1 FROM transport_scopes ts2
+        WHERE ts2.id = p2.scope_id AND ts2.name = @scope_name::text))
+    ORDER BY po3.heard_at DESC
+    LIMIT @scan_depth
+  ) hits
+  GROUP BY hits.packet_hash
+  HAVING (@cursor_ts::timestamptz IS NULL OR NOT EXISTS (
+    SELECT 1 FROM packet_observations px
+    WHERE px.packet_hash = hits.packet_hash
+      AND px.iata = ANY(@iatas::bpchar[])
+      AND px.heard_at >= @cursor_ts))
+  ORDER BY site_heard_at DESC
+  LIMIT @page_limit
+) sh
+JOIN packets p ON p.packet_hash = sh.packet_hash
+LEFT JOIN LATERAL (
+  SELECT observer_id, iata
+  FROM packet_observations
+  WHERE packet_hash = p.packet_hash
+  ORDER BY heard_at DESC
+  LIMIT 1
+) po ON true
+LEFT JOIN observers o ON o.id = po.observer_id
+LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
+ORDER BY sh.site_heard_at DESC;
 
 -- name: ListPacketsAfterID :many
 -- Returns packets with observations after the given observation ID, ordered oldest first.

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -56,7 +56,7 @@ LEFT JOIN observer_scopes os ON os.scope_id = ts.id
 LEFT JOIN observers o ON o.id = os.observer_id
 LEFT JOIN packet_observations po ON po.observer_id = o.id
 LEFT JOIN nodes n ON n.default_scope_id = ts.id
-WHERE ($1::text = '' OR po.iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
 GROUP BY ts.name
 ORDER BY ts.name;
 
@@ -161,11 +161,11 @@ LEFT JOIN observer_brokers ob ON ob.observer_id = o.id
 LEFT JOIN observer_scopes os ON os.observer_id = o.id
 LEFT JOIN transport_scopes ts ON ts.id = os.scope_id
 WHERE
-  ($1::text = '' OR (
+  (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR (
       SELECT po.iata FROM packet_observations po
       WHERE po.observer_id = o.id
       ORDER BY po.heard_at DESC LIMIT 1
-  ) = ANY(string_to_array($1::text, ',')))
+  ) = ANY($1::bpchar[]))
   AND ($2 = '' OR o.observer_type = $2)
   AND ($3 = '' OR ob.broker_name = $3)
   AND ($4 = '' OR CASE
@@ -358,10 +358,10 @@ LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE
   ($1::smallint = -1 OR p.payload_type = $1::smallint)
   AND ($2::smallint = -1 OR p.route_type = $2::smallint)
-  AND ($3::text = '' OR EXISTS (
+  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR EXISTS (
       SELECT 1 FROM packet_observations po3
       WHERE po3.packet_hash = p.packet_hash
-      AND po3.iata = ANY(string_to_array($3::text, ','))
+      AND po3.iata = ANY($3::bpchar[])
   ))
   AND ($4::timestamptz IS NULL OR p.first_heard_at >= $4)
   AND ($5::timestamptz IS NULL OR p.first_heard_at <= $5)
@@ -391,7 +391,7 @@ LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE po.id > $1
   AND ($2::smallint = -1 OR p.payload_type = $2::smallint)
   AND ($3::smallint = -1 OR p.route_type = $3::smallint)
-  AND ($4::text = '' OR po.iata = ANY(string_to_array($4::text, ',')))
+  AND (COALESCE(cardinality($4::bpchar[]), 0) = 0 OR po.iata = ANY($4::bpchar[]))
   AND ($5::text = '' OR ts.name = $5::text)
 ORDER BY po.id ASC
 LIMIT $6;
@@ -505,7 +505,7 @@ LEFT JOIN node_iatas ni ON ni.node_id = n.id
 LEFT JOIN transport_scopes ts ON ts.id = n.default_scope_id
 WHERE
   ($1 = 0 OR n.node_type = $1)
-  AND ($2::text = '' OR n.id IN (SELECT node_id FROM node_iatas WHERE iata = ANY(string_to_array($2::text, ','))))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR n.id IN (SELECT node_id FROM node_iatas WHERE iata = ANY($2::bpchar[])))
   AND (
     $3::text = 'any'
     OR ($3::text = 'true' AND n.supports_multibyte_paths = TRUE)
@@ -618,7 +618,7 @@ JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE cm.channel_id = $1
   AND ($2::timestamptz IS NULL OR cm.sent_at >= $2)
-  AND ($3::text = '' OR po.iata = ANY(string_to_array($3::text, ',')))
+  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR po.iata = ANY($3::bpchar[]))
   AND ($4::text = '' OR ts.name = $4::text)
   AND ($5::bigint = 0 OR cm.id < $5::bigint)
 ORDER BY cm.id DESC
@@ -636,7 +636,7 @@ JOIN packet_observations po ON po.packet_hash = cm.packet_hash
 JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE ($1::timestamptz IS NULL OR cm.sent_at >= $1)
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
   AND ($3::text = '' OR ts.name = $3::text)
   AND ($4 = 0 OR cm.id < $4)
 ORDER BY cm.id DESC
@@ -656,7 +656,7 @@ JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE c.channel_hash = $1
   AND ($2::timestamptz IS NULL OR cm.sent_at >= $2)
-  AND ($3::text = '' OR po.iata = ANY(string_to_array($3::text, ',')))
+  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR po.iata = ANY($3::bpchar[]))
   AND ($4::text = '' OR ts.name = $4::text)
   AND ($5::bigint = 0 OR cm.id < $5::bigint)
 ORDER BY cm.id DESC
@@ -673,7 +673,7 @@ JOIN packet_observations po ON po.packet_hash = cm.packet_hash
 JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE cm.id > $1
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
   AND ($3::text = '' OR ts.name = $3::text)
 ORDER BY cm.id ASC
 LIMIT $4;
@@ -690,18 +690,18 @@ SELECT
   COUNT(DISTINCT po.iata)         AS active_iatas
 FROM packet_observations po
 WHERE po.heard_at > NOW() - INTERVAL '24 hours'
-  AND ($1::text = '' OR po.iata = ANY(string_to_array($1::text, ',')));
+  AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]));
 
 -- name: GetHourlyStats :many
 SELECT iata, hour, observation_count, unique_packets, active_observers
 FROM mv_hourly_iata_stats
-WHERE ($1::text = '' OR iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR iata = ANY($1::bpchar[]))
   AND hour >= NOW() - $2::interval
 ORDER BY iata, hour;
 
 -- name: GetTopNodes :many
 SELECT * FROM mv_top_nodes_by_iata
-WHERE ($1::text = '' OR iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR iata = ANY($1::bpchar[]))
 ORDER BY observation_count DESC
 LIMIT $2;
 
@@ -713,7 +713,7 @@ SELECT
 FROM packet_observations po
 JOIN packets p ON p.packet_hash = po.packet_hash
 WHERE po.heard_at > $1
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
 GROUP BY p.payload_type
 ORDER BY count DESC;
 
@@ -724,7 +724,7 @@ SELECT
   COUNT(DISTINCT n.id)::bigint AS count
 FROM nodes n
 LEFT JOIN node_iatas ni ON ni.node_id = n.id
-WHERE ($1::text = '' OR ni.iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR ni.iata = ANY($1::bpchar[]))
 GROUP BY n.node_type
 ORDER BY count DESC;
 
@@ -743,7 +743,7 @@ SELECT
 FROM packet_observations po
 JOIN observers o ON o.id = po.observer_id
 WHERE po.heard_at > $1
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
 GROUP BY o.id
 ORDER BY observation_count DESC
 LIMIT $3;
@@ -752,7 +752,7 @@ LIMIT $3;
 SELECT preset, iata, source_type, count
 FROM mv_radio_presets
 WHERE ($1::text = '' OR preset = $1::text)
-  AND ($2::text = '' OR iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR iata = ANY($2::bpchar[]))
 ORDER BY preset, iata, source_type;
 
 -- name: GetScopeStats :many
@@ -834,7 +834,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) best ON true
 WHERE p.trace_tag IS NOT NULL
-  AND ($1::text = '' OR po.iata = ANY(string_to_array($1::text, ',')))
+  AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
   AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
   AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
   AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)

--- a/db/scopes.go
+++ b/db/scopes.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"context"
-	"strings"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
 	"github.com/MeshCore-Beacon/beacon-server/internal/api"
@@ -52,8 +51,7 @@ func (s *Store) GetScopeNames(ctx context.Context) ([]string, error) {
 
 // GetScopesByIATAs returns scope summaries filtered by the given IATA codes.
 func (s *Store) GetScopesByIATAs(ctx context.Context, iatas []string) ([]api.ScopeSummary, error) {
-	iataFilter := strings.Join(iatas, ",")
-	rows, err := s.q.GetScopesByIATAs(ctx, iataFilter)
+	rows, err := s.q.GetScopesByIATAs(ctx, iatas)
 	if err != nil {
 		return nil, err
 	}

--- a/db/scopes_test.go
+++ b/db/scopes_test.go
@@ -48,7 +48,7 @@ func TestGetScopesByIATAs(t *testing.T) {
 	mock := mockdb.NewMockQuerier(ctrl)
 
 	mock.EXPECT().
-		GetScopesByIATAs(gomock.Any(), "YVR,YYJ").
+		GetScopesByIATAs(gomock.Any(), []string{"YVR", "YYJ"}).
 		Return([]sqlc.GetScopesByIATAsRow{
 			{Name: "default", ObserverCount: 3, NodeCount: 10, IataCount: 2},
 		}, nil)

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -477,7 +477,7 @@ func (mr *MockQuerierMockRecorder) GetScopeStats(ctx any) *gomock.Call {
 }
 
 // GetScopesByIATAs mocks base method.
-func (m *MockQuerier) GetScopesByIATAs(ctx context.Context, dollar_1 string) ([]db.GetScopesByIATAsRow, error) {
+func (m *MockQuerier) GetScopesByIATAs(ctx context.Context, dollar_1 []string) ([]db.GetScopesByIATAsRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetScopesByIATAs", ctx, dollar_1)
 	ret0, _ := ret[0].([]db.GetScopesByIATAsRow)
@@ -492,7 +492,7 @@ func (mr *MockQuerierMockRecorder) GetScopesByIATAs(ctx, dollar_1 any) *gomock.C
 }
 
 // GetStatsNodeTypes mocks base method.
-func (m *MockQuerier) GetStatsNodeTypes(ctx context.Context, dollar_1 string) ([]db.GetStatsNodeTypesRow, error) {
+func (m *MockQuerier) GetStatsNodeTypes(ctx context.Context, dollar_1 []string) ([]db.GetStatsNodeTypesRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatsNodeTypes", ctx, dollar_1)
 	ret0, _ := ret[0].([]db.GetStatsNodeTypesRow)
@@ -507,7 +507,7 @@ func (mr *MockQuerierMockRecorder) GetStatsNodeTypes(ctx, dollar_1 any) *gomock.
 }
 
 // GetStatsOverview mocks base method.
-func (m *MockQuerier) GetStatsOverview(ctx context.Context, dollar_1 string) (db.GetStatsOverviewRow, error) {
+func (m *MockQuerier) GetStatsOverview(ctx context.Context, dollar_1 []string) (db.GetStatsOverviewRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatsOverview", ctx, dollar_1)
 	ret0, _ := ret[0].(db.GetStatsOverviewRow)

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -850,6 +850,21 @@ func (mr *MockQuerierMockRecorder) ListPacketsAfterID(ctx, arg any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPacketsAfterID", reflect.TypeOf((*MockQuerier)(nil).ListPacketsAfterID), ctx, arg)
 }
 
+// ListPacketsByIATAs mocks base method.
+func (m *MockQuerier) ListPacketsByIATAs(ctx context.Context, arg db.ListPacketsByIATAsParams) ([]db.ListPacketsByIATAsRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPacketsByIATAs", ctx, arg)
+	ret0, _ := ret[0].([]db.ListPacketsByIATAsRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPacketsByIATAs indicates an expected call of ListPacketsByIATAs.
+func (mr *MockQuerierMockRecorder) ListPacketsByIATAs(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPacketsByIATAs", reflect.TypeOf((*MockQuerier)(nil).ListPacketsByIATAs), ctx, arg)
+}
+
 // ListRegions mocks base method.
 func (m *MockQuerier) ListRegions(ctx context.Context) ([]db.ListRegionsRow, error) {
 	m.ctrl.T.Helper()

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -47,13 +47,13 @@ type Querier interface {
 	GetScopeByName(ctx context.Context, name string) (GetScopeByNameRow, error)
 	GetScopeNames(ctx context.Context) ([]string, error)
 	GetScopeStats(ctx context.Context) ([]GetScopeStatsRow, error)
-	GetScopesByIATAs(ctx context.Context, dollar_1 string) ([]GetScopesByIATAsRow, error)
+	GetScopesByIATAs(ctx context.Context, dollar_1 []string) ([]GetScopesByIATAsRow, error)
 	// Returns node counts grouped by type, optionally filtered by IATA.
-	GetStatsNodeTypes(ctx context.Context, dollar_1 string) ([]GetStatsNodeTypesRow, error)
+	GetStatsNodeTypes(ctx context.Context, dollar_1 []string) ([]GetStatsNodeTypesRow, error)
 	// ============================================================
 	// STATS
 	// ============================================================
-	GetStatsOverview(ctx context.Context, dollar_1 string) (GetStatsOverviewRow, error)
+	GetStatsOverview(ctx context.Context, dollar_1 []string) (GetStatsOverviewRow, error)
 	// Returns observation counts grouped by payload type for the given window and IATA.
 	GetStatsPayloadBreakdown(ctx context.Context, arg GetStatsPayloadBreakdownParams) ([]GetStatsPayloadBreakdownRow, error)
 	// Returns the top N observers by observation count for the given window and IATA.

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -106,11 +106,22 @@ type Querier interface {
 	// Note: observers use UUID PKs so we order by last_seen and use a keyset on last_seen+id.
 	ListObservers(ctx context.Context, arg ListObserversParams) ([]ListObserversRow, error)
 	// Returns packets with the latest observation rolled in for display.
-	// Pass cursor=0 to start from the beginning.
+	// Pass cursor=0 to start from the beginning. IATA-filtered requests are
+	// served by ListPacketsByIATAs instead.
 	ListPackets(ctx context.Context, arg ListPacketsParams) ([]ListPacketsRow, error)
 	// Returns packets with observations after the given observation ID, ordered oldest first.
 	// Used for WS reconnect backfill. Pass afterObservationId=0 to start from the beginning.
 	ListPacketsAfterID(ctx context.Context, arg ListPacketsAfterIDParams) ([]ListPacketsAfterIDRow, error)
+	// IATA-filtered packet list, driven from idx_observations_iata_heard.
+	// Walking packets newest-first and probing for the site probes ~589k packets
+	// to fill a page for a quiet site; walking the site's own observation log is
+	// proportional to the page size instead. Results are ordered by when the
+	// requested sites heard the packet (site-local recency) and the cursor
+	// follows that ordering. scan_depth is a multiple of the page size to
+	// absorb per-observer duplicates; if duplication exceeds it across a
+	// page, pagination ends early (hasMore=false) rather than returning a
+	// short page, even though deeper matches exist.
+	ListPacketsByIATAs(ctx context.Context, arg ListPacketsByIATAsParams) ([]ListPacketsByIATAsRow, error)
 	// ============================================================
 	// REGIONS
 	// ============================================================

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -2433,28 +2433,22 @@ LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE
   ($1::smallint = -1 OR p.payload_type = $1::smallint)
   AND ($2::smallint = -1 OR p.route_type = $2::smallint)
-  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR EXISTS (
-      SELECT 1 FROM packet_observations po3
-      WHERE po3.packet_hash = p.packet_hash
-      AND po3.iata = ANY($3::bpchar[])
-  ))
-  AND ($4::timestamptz IS NULL OR p.first_heard_at >= $4)
-  AND ($5::timestamptz IS NULL OR p.first_heard_at <= $5)
-  AND ($6::timestamptz IS NULL OR p.last_heard_at < $6)
-  AND ($8::text = '' OR ts.name = $8::text)
+  AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
+  AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
+  AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
+  AND ($7::text = '' OR ts.name = $7::text)
 ORDER BY p.last_heard_at DESC
-LIMIT $7
+LIMIT $6
 `
 
 type ListPacketsParams struct {
 	Column1 int16              `json:"column_1"`
 	Column2 int16              `json:"column_2"`
-	Column3 []string           `json:"column_3"`
+	Column3 pgtype.Timestamptz `json:"column_3"`
 	Column4 pgtype.Timestamptz `json:"column_4"`
 	Column5 pgtype.Timestamptz `json:"column_5"`
-	Column6 pgtype.Timestamptz `json:"column_6"`
 	Limit   int32              `json:"limit"`
-	Column8 string             `json:"column_8"`
+	Column7 string             `json:"column_7"`
 }
 
 type ListPacketsRow struct {
@@ -2472,7 +2466,8 @@ type ListPacketsRow struct {
 }
 
 // Returns packets with the latest observation rolled in for display.
-// Pass cursor=0 to start from the beginning.
+// Pass cursor=0 to start from the beginning. IATA-filtered requests are
+// served by ListPacketsByIATAs instead.
 func (q *Queries) ListPackets(ctx context.Context, arg ListPacketsParams) ([]ListPacketsRow, error) {
 	rows, err := q.db.Query(ctx, listPackets,
 		arg.Column1,
@@ -2480,9 +2475,8 @@ func (q *Queries) ListPackets(ctx context.Context, arg ListPacketsParams) ([]Lis
 		arg.Column3,
 		arg.Column4,
 		arg.Column5,
-		arg.Column6,
 		arg.Limit,
-		arg.Column8,
+		arg.Column7,
 	)
 	if err != nil {
 		return nil, err
@@ -2590,6 +2584,140 @@ func (q *Queries) ListPacketsAfterID(ctx context.Context, arg ListPacketsAfterID
 			&i.LatestObserverName,
 			&i.LatestObserverIata,
 			&i.ScopeName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPacketsByIATAs = `-- name: ListPacketsByIATAs :many
+SELECT
+  p.packet_hash,
+  p.payload_type,
+  p.route_type,
+  p.first_heard_at,
+  p.last_heard_at,
+  p.scope_id,
+  ts.name AS scope_name,
+  sh.site_heard_at,
+  (SELECT COUNT(*) FROM packet_observations po2 WHERE po2.packet_hash = p.packet_hash) AS observation_count,
+  po.observer_id AS latest_observer_id,
+  o.display_name AS latest_observer_name,
+  po.iata AS latest_observer_iata
+FROM (
+  SELECT hits.packet_hash, MAX(hits.heard_at)::timestamptz AS site_heard_at
+  FROM unnest($1::bpchar[]) AS req(iata)
+  CROSS JOIN LATERAL (
+    SELECT po3.packet_hash, po3.heard_at
+    FROM packet_observations po3
+    JOIN packets p2 ON p2.packet_hash = po3.packet_hash
+    WHERE po3.iata = req.iata
+      AND po3.heard_at < COALESCE($2::timestamptz, 'infinity'::timestamptz)
+      AND ($3::smallint = -1 OR p2.payload_type = $3::smallint)
+      AND ($4::smallint = -1 OR p2.route_type = $4::smallint)
+      AND ($5::timestamptz IS NULL OR p2.first_heard_at >= $5)
+      AND ($6::timestamptz IS NULL OR p2.first_heard_at <= $6)
+      AND ($7::text = '' OR EXISTS (
+        SELECT 1 FROM transport_scopes ts2
+        WHERE ts2.id = p2.scope_id AND ts2.name = $7::text))
+    ORDER BY po3.heard_at DESC
+    LIMIT $8
+  ) hits
+  GROUP BY hits.packet_hash
+  HAVING ($2::timestamptz IS NULL OR NOT EXISTS (
+    SELECT 1 FROM packet_observations px
+    WHERE px.packet_hash = hits.packet_hash
+      AND px.iata = ANY($1::bpchar[])
+      AND px.heard_at >= $2))
+  ORDER BY site_heard_at DESC
+  LIMIT $9
+) sh
+JOIN packets p ON p.packet_hash = sh.packet_hash
+LEFT JOIN LATERAL (
+  SELECT observer_id, iata
+  FROM packet_observations
+  WHERE packet_hash = p.packet_hash
+  ORDER BY heard_at DESC
+  LIMIT 1
+) po ON true
+LEFT JOIN observers o ON o.id = po.observer_id
+LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
+ORDER BY sh.site_heard_at DESC
+`
+
+type ListPacketsByIATAsParams struct {
+	Iatas       []string           `json:"iatas"`
+	CursorTs    pgtype.Timestamptz `json:"cursor_ts"`
+	PayloadType int16              `json:"payload_type"`
+	RouteType   int16              `json:"route_type"`
+	SinceTs     pgtype.Timestamptz `json:"since_ts"`
+	UntilTs     pgtype.Timestamptz `json:"until_ts"`
+	ScopeName   string             `json:"scope_name"`
+	ScanDepth   int32              `json:"scan_depth"`
+	PageLimit   int32              `json:"page_limit"`
+}
+
+type ListPacketsByIATAsRow struct {
+	PacketHash         []byte             `json:"packet_hash"`
+	PayloadType        int16              `json:"payload_type"`
+	RouteType          int16              `json:"route_type"`
+	FirstHeardAt       pgtype.Timestamptz `json:"first_heard_at"`
+	LastHeardAt        pgtype.Timestamptz `json:"last_heard_at"`
+	ScopeID            *int32             `json:"scope_id"`
+	ScopeName          *string            `json:"scope_name"`
+	SiteHeardAt        pgtype.Timestamptz `json:"site_heard_at"`
+	ObservationCount   int64              `json:"observation_count"`
+	LatestObserverID   uuid.UUID          `json:"latest_observer_id"`
+	LatestObserverName *string            `json:"latest_observer_name"`
+	LatestObserverIata string             `json:"latest_observer_iata"`
+}
+
+// IATA-filtered packet list, driven from idx_observations_iata_heard.
+// Walking packets newest-first and probing for the site probes ~589k packets
+// to fill a page for a quiet site; walking the site's own observation log is
+// proportional to the page size instead. Results are ordered by when the
+// requested sites heard the packet (site-local recency) and the cursor
+// follows that ordering. scan_depth is a multiple of the page size to
+// absorb per-observer duplicates; if duplication exceeds it across a
+// page, pagination ends early (hasMore=false) rather than returning a
+// short page, even though deeper matches exist.
+func (q *Queries) ListPacketsByIATAs(ctx context.Context, arg ListPacketsByIATAsParams) ([]ListPacketsByIATAsRow, error) {
+	rows, err := q.db.Query(ctx, listPacketsByIATAs,
+		arg.Iatas,
+		arg.CursorTs,
+		arg.PayloadType,
+		arg.RouteType,
+		arg.SinceTs,
+		arg.UntilTs,
+		arg.ScopeName,
+		arg.ScanDepth,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPacketsByIATAsRow{}
+	for rows.Next() {
+		var i ListPacketsByIATAsRow
+		if err := rows.Scan(
+			&i.PacketHash,
+			&i.PayloadType,
+			&i.RouteType,
+			&i.FirstHeardAt,
+			&i.LastHeardAt,
+			&i.ScopeID,
+			&i.ScopeName,
+			&i.SiteHeardAt,
+			&i.ObservationCount,
+			&i.LatestObserverID,
+			&i.LatestObserverName,
+			&i.LatestObserverIata,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -118,13 +118,13 @@ func (q *Queries) GetCrossIATANeighbors(ctx context.Context, arg GetCrossIATANei
 const getHourlyStats = `-- name: GetHourlyStats :many
 SELECT iata, hour, observation_count, unique_packets, active_observers
 FROM mv_hourly_iata_stats
-WHERE ($1::text = '' OR iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR iata = ANY($1::bpchar[]))
   AND hour >= NOW() - $2::interval
 ORDER BY iata, hour
 `
 
 type GetHourlyStatsParams struct {
-	Column1 string          `json:"column_1"`
+	Column1 []string        `json:"column_1"`
 	Column2 pgtype.Interval `json:"column_2"`
 }
 
@@ -823,13 +823,13 @@ const getRadioPresets = `-- name: GetRadioPresets :many
 SELECT preset, iata, source_type, count
 FROM mv_radio_presets
 WHERE ($1::text = '' OR preset = $1::text)
-  AND ($2::text = '' OR iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR iata = ANY($2::bpchar[]))
 ORDER BY preset, iata, source_type
 `
 
 type GetRadioPresetsParams struct {
-	Column1 string `json:"column_1"`
-	Column2 string `json:"column_2"`
+	Column1 string   `json:"column_1"`
+	Column2 []string `json:"column_2"`
 }
 
 func (q *Queries) GetRadioPresets(ctx context.Context, arg GetRadioPresetsParams) ([]MvRadioPreset, error) {
@@ -1067,7 +1067,7 @@ LEFT JOIN observer_scopes os ON os.scope_id = ts.id
 LEFT JOIN observers o ON o.id = os.observer_id
 LEFT JOIN packet_observations po ON po.observer_id = o.id
 LEFT JOIN nodes n ON n.default_scope_id = ts.id
-WHERE ($1::text = '' OR po.iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
 GROUP BY ts.name
 ORDER BY ts.name
 `
@@ -1079,7 +1079,7 @@ type GetScopesByIATAsRow struct {
 	IataCount     int64  `json:"iata_count"`
 }
 
-func (q *Queries) GetScopesByIATAs(ctx context.Context, dollar_1 string) ([]GetScopesByIATAsRow, error) {
+func (q *Queries) GetScopesByIATAs(ctx context.Context, dollar_1 []string) ([]GetScopesByIATAsRow, error) {
 	rows, err := q.db.Query(ctx, getScopesByIATAs, dollar_1)
 	if err != nil {
 		return nil, err
@@ -1110,7 +1110,7 @@ SELECT
   COUNT(DISTINCT n.id)::bigint AS count
 FROM nodes n
 LEFT JOIN node_iatas ni ON ni.node_id = n.id
-WHERE ($1::text = '' OR ni.iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR ni.iata = ANY($1::bpchar[]))
 GROUP BY n.node_type
 ORDER BY count DESC
 `
@@ -1121,7 +1121,7 @@ type GetStatsNodeTypesRow struct {
 }
 
 // Returns node counts grouped by type, optionally filtered by IATA.
-func (q *Queries) GetStatsNodeTypes(ctx context.Context, dollar_1 string) ([]GetStatsNodeTypesRow, error) {
+func (q *Queries) GetStatsNodeTypes(ctx context.Context, dollar_1 []string) ([]GetStatsNodeTypesRow, error) {
 	rows, err := q.db.Query(ctx, getStatsNodeTypes, dollar_1)
 	if err != nil {
 		return nil, err
@@ -1150,7 +1150,7 @@ SELECT
   COUNT(DISTINCT po.iata)         AS active_iatas
 FROM packet_observations po
 WHERE po.heard_at > NOW() - INTERVAL '24 hours'
-  AND ($1::text = '' OR po.iata = ANY(string_to_array($1::text, ',')))
+  AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
 `
 
 type GetStatsOverviewRow struct {
@@ -1163,7 +1163,7 @@ type GetStatsOverviewRow struct {
 // ============================================================
 // STATS
 // ============================================================
-func (q *Queries) GetStatsOverview(ctx context.Context, dollar_1 string) (GetStatsOverviewRow, error) {
+func (q *Queries) GetStatsOverview(ctx context.Context, dollar_1 []string) (GetStatsOverviewRow, error) {
 	row := q.db.QueryRow(ctx, getStatsOverview, dollar_1)
 	var i GetStatsOverviewRow
 	err := row.Scan(
@@ -1182,14 +1182,14 @@ SELECT
 FROM packet_observations po
 JOIN packets p ON p.packet_hash = po.packet_hash
 WHERE po.heard_at > $1
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
 GROUP BY p.payload_type
 ORDER BY count DESC
 `
 
 type GetStatsPayloadBreakdownParams struct {
 	HeardAt pgtype.Timestamptz `json:"heard_at"`
-	Column2 string             `json:"column_2"`
+	Column2 []string           `json:"column_2"`
 }
 
 type GetStatsPayloadBreakdownRow struct {
@@ -1232,7 +1232,7 @@ SELECT
 FROM packet_observations po
 JOIN observers o ON o.id = po.observer_id
 WHERE po.heard_at > $1
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
 GROUP BY o.id
 ORDER BY observation_count DESC
 LIMIT $3
@@ -1240,7 +1240,7 @@ LIMIT $3
 
 type GetStatsTopObserversParams struct {
 	HeardAt pgtype.Timestamptz `json:"heard_at"`
-	Column2 string             `json:"column_2"`
+	Column2 []string           `json:"column_2"`
 	Limit   int32              `json:"limit"`
 }
 
@@ -1281,14 +1281,14 @@ func (q *Queries) GetStatsTopObservers(ctx context.Context, arg GetStatsTopObser
 
 const getTopNodes = `-- name: GetTopNodes :many
 SELECT iata, node_id, name, node_type, observation_count, last_heard FROM mv_top_nodes_by_iata
-WHERE ($1::text = '' OR iata = ANY(string_to_array($1::text, ',')))
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR iata = ANY($1::bpchar[]))
 ORDER BY observation_count DESC
 LIMIT $2
 `
 
 type GetTopNodesParams struct {
-	Column1 string `json:"column_1"`
-	Limit   int32  `json:"limit"`
+	Column1 []string `json:"column_1"`
+	Limit   int32    `json:"limit"`
 }
 
 func (q *Queries) GetTopNodes(ctx context.Context, arg GetTopNodesParams) ([]MvTopNodesByIatum, error) {
@@ -1530,7 +1530,7 @@ JOIN packet_observations po ON po.packet_hash = cm.packet_hash
 JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE ($1::timestamptz IS NULL OR cm.sent_at >= $1)
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
   AND ($3::text = '' OR ts.name = $3::text)
   AND ($4 = 0 OR cm.id < $4)
 ORDER BY cm.id DESC
@@ -1539,7 +1539,7 @@ LIMIT $5
 
 type ListAllChannelMessagesParams struct {
 	Column1 pgtype.Timestamptz `json:"column_1"`
-	Column2 string             `json:"column_2"`
+	Column2 []string           `json:"column_2"`
 	Column3 string             `json:"column_3"`
 	Column4 interface{}        `json:"column_4"`
 	Limit   int32              `json:"limit"`
@@ -1608,7 +1608,7 @@ JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE cm.channel_id = $1
   AND ($2::timestamptz IS NULL OR cm.sent_at >= $2)
-  AND ($3::text = '' OR po.iata = ANY(string_to_array($3::text, ',')))
+  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR po.iata = ANY($3::bpchar[]))
   AND ($4::text = '' OR ts.name = $4::text)
   AND ($5::bigint = 0 OR cm.id < $5::bigint)
 ORDER BY cm.id DESC
@@ -1618,7 +1618,7 @@ LIMIT $6
 type ListChannelMessagesParams struct {
 	ChannelID int32              `json:"channel_id"`
 	Column2   pgtype.Timestamptz `json:"column_2"`
-	Column3   string             `json:"column_3"`
+	Column3   []string           `json:"column_3"`
 	Column4   string             `json:"column_4"`
 	Column5   int64              `json:"column_5"`
 	Limit     int32              `json:"limit"`
@@ -1689,7 +1689,7 @@ JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE c.channel_hash = $1
   AND ($2::timestamptz IS NULL OR cm.sent_at >= $2)
-  AND ($3::text = '' OR po.iata = ANY(string_to_array($3::text, ',')))
+  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR po.iata = ANY($3::bpchar[]))
   AND ($4::text = '' OR ts.name = $4::text)
   AND ($5::bigint = 0 OR cm.id < $5::bigint)
 ORDER BY cm.id DESC
@@ -1699,7 +1699,7 @@ LIMIT $6
 type ListChannelMessagesByHashParams struct {
 	ChannelHash []byte             `json:"channel_hash"`
 	Column2     pgtype.Timestamptz `json:"column_2"`
-	Column3     string             `json:"column_3"`
+	Column3     []string           `json:"column_3"`
 	Column4     string             `json:"column_4"`
 	Column5     int64              `json:"column_5"`
 	Limit       int32              `json:"limit"`
@@ -1910,17 +1910,17 @@ JOIN packet_observations po ON po.packet_hash = cm.packet_hash
 JOIN packets p ON p.packet_hash = cm.packet_hash
 LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE cm.id > $1
-  AND ($2::text = '' OR po.iata = ANY(string_to_array($2::text, ',')))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
   AND ($3::text = '' OR ts.name = $3::text)
 ORDER BY cm.id ASC
 LIMIT $4
 `
 
 type ListMessagesAfterIDParams struct {
-	ID      int64  `json:"id"`
-	Column2 string `json:"column_2"`
-	Column3 string `json:"column_3"`
-	Limit   int32  `json:"limit"`
+	ID      int64    `json:"id"`
+	Column2 []string `json:"column_2"`
+	Column3 string   `json:"column_3"`
+	Limit   int32    `json:"limit"`
 }
 
 type ListMessagesAfterIDRow struct {
@@ -2050,7 +2050,7 @@ LEFT JOIN node_iatas ni ON ni.node_id = n.id
 LEFT JOIN transport_scopes ts ON ts.id = n.default_scope_id
 WHERE
   ($1 = 0 OR n.node_type = $1)
-  AND ($2::text = '' OR n.id IN (SELECT node_id FROM node_iatas WHERE iata = ANY(string_to_array($2::text, ','))))
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR n.id IN (SELECT node_id FROM node_iatas WHERE iata = ANY($2::bpchar[])))
   AND (
     $3::text = 'any'
     OR ($3::text = 'true' AND n.supports_multibyte_paths = TRUE)
@@ -2072,7 +2072,7 @@ LIMIT $8
 
 type ListNodesParams struct {
 	Column1  interface{}        `json:"column_1"`
-	Column2  string             `json:"column_2"`
+	Column2  []string           `json:"column_2"`
 	Column3  string             `json:"column_3"`
 	Column4  string             `json:"column_4"`
 	Column5  []byte             `json:"column_5"`
@@ -2318,11 +2318,11 @@ LEFT JOIN observer_brokers ob ON ob.observer_id = o.id
 LEFT JOIN observer_scopes os ON os.observer_id = o.id
 LEFT JOIN transport_scopes ts ON ts.id = os.scope_id
 WHERE
-  ($1::text = '' OR (
+  (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR (
       SELECT po.iata FROM packet_observations po
       WHERE po.observer_id = o.id
       ORDER BY po.heard_at DESC LIMIT 1
-  ) = ANY(string_to_array($1::text, ',')))
+  ) = ANY($1::bpchar[]))
   AND ($2 = '' OR o.observer_type = $2)
   AND ($3 = '' OR ob.broker_name = $3)
   AND ($4 = '' OR CASE
@@ -2342,7 +2342,7 @@ LIMIT $7
 `
 
 type ListObserversParams struct {
-	Column1 string             `json:"column_1"`
+	Column1 []string           `json:"column_1"`
 	Column2 interface{}        `json:"column_2"`
 	Column3 interface{}        `json:"column_3"`
 	Column4 interface{}        `json:"column_4"`
@@ -2433,10 +2433,10 @@ LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE
   ($1::smallint = -1 OR p.payload_type = $1::smallint)
   AND ($2::smallint = -1 OR p.route_type = $2::smallint)
-  AND ($3::text = '' OR EXISTS (
+  AND (COALESCE(cardinality($3::bpchar[]), 0) = 0 OR EXISTS (
       SELECT 1 FROM packet_observations po3
       WHERE po3.packet_hash = p.packet_hash
-      AND po3.iata = ANY(string_to_array($3::text, ','))
+      AND po3.iata = ANY($3::bpchar[])
   ))
   AND ($4::timestamptz IS NULL OR p.first_heard_at >= $4)
   AND ($5::timestamptz IS NULL OR p.first_heard_at <= $5)
@@ -2449,7 +2449,7 @@ LIMIT $7
 type ListPacketsParams struct {
 	Column1 int16              `json:"column_1"`
 	Column2 int16              `json:"column_2"`
-	Column3 string             `json:"column_3"`
+	Column3 []string           `json:"column_3"`
 	Column4 pgtype.Timestamptz `json:"column_4"`
 	Column5 pgtype.Timestamptz `json:"column_5"`
 	Column6 pgtype.Timestamptz `json:"column_6"`
@@ -2533,19 +2533,19 @@ LEFT JOIN transport_scopes ts ON ts.id = p.scope_id
 WHERE po.id > $1
   AND ($2::smallint = -1 OR p.payload_type = $2::smallint)
   AND ($3::smallint = -1 OR p.route_type = $3::smallint)
-  AND ($4::text = '' OR po.iata = ANY(string_to_array($4::text, ',')))
+  AND (COALESCE(cardinality($4::bpchar[]), 0) = 0 OR po.iata = ANY($4::bpchar[]))
   AND ($5::text = '' OR ts.name = $5::text)
 ORDER BY po.id ASC
 LIMIT $6
 `
 
 type ListPacketsAfterIDParams struct {
-	ID      int64  `json:"id"`
-	Column2 int16  `json:"column_2"`
-	Column3 int16  `json:"column_3"`
-	Column4 string `json:"column_4"`
-	Column5 string `json:"column_5"`
-	Limit   int32  `json:"limit"`
+	ID      int64    `json:"id"`
+	Column2 int16    `json:"column_2"`
+	Column3 int16    `json:"column_3"`
+	Column4 []string `json:"column_4"`
+	Column5 string   `json:"column_5"`
+	Limit   int32    `json:"limit"`
 }
 
 type ListPacketsAfterIDRow struct {
@@ -2657,7 +2657,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) best ON true
 WHERE p.trace_tag IS NOT NULL
-  AND ($1::text = '' OR po.iata = ANY(string_to_array($1::text, ',')))
+  AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
   AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
   AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
   AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
@@ -2669,7 +2669,7 @@ LIMIT $6
 `
 
 type ListTraceTagsParams struct {
-	Column1 string             `json:"column_1"`
+	Column1 []string           `json:"column_1"`
 	Column2 string             `json:"column_2"`
 	Column3 pgtype.Timestamptz `json:"column_3"`
 	Column4 pgtype.Timestamptz `json:"column_4"`

--- a/db/stats.go
+++ b/db/stats.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
@@ -14,7 +13,7 @@ import (
 )
 
 func (s *Store) GetStatsOverview(ctx context.Context, iatas []string) (*api.StatsOverview, error) {
-	row, err := s.q.GetStatsOverview(ctx, strings.Join(iatas, ","))
+	row, err := s.q.GetStatsOverview(ctx, iatas)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +32,7 @@ func (s *Store) GetStatsObservations(ctx context.Context, iatas []string, since 
 	}
 	interval := time.Since(since)
 	rows, err := s.q.GetHourlyStats(ctx, sqlc.GetHourlyStatsParams{
-		Column1: strings.Join(iatas, ","),
+		Column1: iatas,
 		Column2: pgtype.Interval{Microseconds: int64(interval.Hours()) * 3600 * 1e6, Valid: true},
 	})
 	if err != nil {
@@ -58,7 +57,7 @@ func (s *Store) GetStatsPayloadBreakdown(ctx context.Context, iatas []string, si
 	}
 	rows, err := s.q.GetStatsPayloadBreakdown(ctx, sqlc.GetStatsPayloadBreakdownParams{
 		HeardAt: pgtype.Timestamptz{Time: since, Valid: true},
-		Column2: strings.Join(iatas, ","),
+		Column2: iatas,
 	})
 	if err != nil {
 		return nil, err
@@ -76,7 +75,7 @@ func (s *Store) GetStatsPayloadBreakdown(ctx context.Context, iatas []string, si
 
 func (s *Store) GetStatsTopNodes(ctx context.Context, iatas []string, limit int32) ([]api.TopNode, error) {
 	rows, err := s.q.GetTopNodes(ctx, sqlc.GetTopNodesParams{
-		Column1: strings.Join(iatas, ","),
+		Column1: iatas,
 		Limit:   limit,
 	})
 	if err != nil {
@@ -107,7 +106,7 @@ func (s *Store) GetStatsTopObservers(ctx context.Context, iatas []string, since 
 	}
 	rows, err := s.q.GetStatsTopObservers(ctx, sqlc.GetStatsTopObserversParams{
 		HeardAt: pgtype.Timestamptz{Time: since, Valid: true},
-		Column2: strings.Join(iatas, ","),
+		Column2: iatas,
 		Limit:   limit,
 	})
 	if err != nil {
@@ -130,7 +129,7 @@ func (s *Store) GetStatsTopObservers(ctx context.Context, iatas []string, since 
 func (s *Store) GetRadioPresets(ctx context.Context, preset string, iatas []string) ([]api.RadioPreset, error) {
 	rows, err := s.q.GetRadioPresets(ctx, sqlc.GetRadioPresetsParams{
 		Column1: preset,
-		Column2: strings.Join(iatas, ","),
+		Column2: iatas,
 	})
 	if err != nil {
 		return nil, err
@@ -165,7 +164,7 @@ func (s *Store) GetScopeStats(ctx context.Context) ([]api.ScopeStats, error) {
 }
 
 func (s *Store) GetStatsNodeTypes(ctx context.Context, iatas []string) ([]api.NodeTypeCount, error) {
-	rows, err := s.q.GetStatsNodeTypes(ctx, strings.Join(iatas, ","))
+	rows, err := s.q.GetStatsNodeTypes(ctx, iatas)
 	if err != nil {
 		return nil, err
 	}

--- a/db/stats_test.go
+++ b/db/stats_test.go
@@ -20,7 +20,7 @@ func TestGetStatsOverview(t *testing.T) {
 	mock := mockdb.NewMockQuerier(ctrl)
 
 	mock.EXPECT().
-		GetStatsOverview(gomock.Any(), "YVR").
+		GetStatsOverview(gomock.Any(), []string{"YVR"}).
 		Return(sqlc.GetStatsOverviewRow{
 			TotalPackets:      100,
 			TotalObservations: 500,
@@ -51,7 +51,7 @@ func TestGetStatsTopNodes_NilObservationCount(t *testing.T) {
 
 	mock.EXPECT().
 		GetTopNodes(gomock.Any(), sqlc.GetTopNodesParams{
-			Column1: "YVR",
+			Column1: []string{"YVR"},
 			Limit:   5,
 		}).
 		Return([]sqlc.MvTopNodesByIatum{
@@ -119,7 +119,7 @@ func TestGetStatsNodeTypes_Mapping(t *testing.T) {
 	mock := mockdb.NewMockQuerier(ctrl)
 
 	mock.EXPECT().
-		GetStatsNodeTypes(gomock.Any(), "YVR").
+		GetStatsNodeTypes(gomock.Any(), []string{"YVR"}).
 		Return([]sqlc.GetStatsNodeTypesRow{
 			{NodeType: 1, Count: 10},
 			{NodeType: 2, Count: 5},

--- a/db/traces.go
+++ b/db/traces.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"strings"
 	"time"
 
 	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
@@ -22,7 +21,6 @@ type tracePayload struct {
 }
 
 func (s *Store) ListTraceTags(ctx context.Context, iatas []string, scope, traceType string, since, until time.Time, cursor time.Time, limit int32) ([]api.TraceTagSummary, error) {
-	iataFilter := strings.Join(iatas, ",")
 	var sinceTS, untilTS, cursorTS pgtype.Timestamptz
 	if !since.IsZero() {
 		sinceTS = pgtype.Timestamptz{Time: since, Valid: true}
@@ -34,7 +32,7 @@ func (s *Store) ListTraceTags(ctx context.Context, iatas []string, scope, traceT
 		cursorTS = pgtype.Timestamptz{Time: cursor, Valid: true}
 	}
 	rows, err := s.q.ListTraceTags(ctx, sqlc.ListTraceTagsParams{
-		Column1: iataFilter,
+		Column1: iatas,
 		Column2: scope,
 		Column3: sinceTS,
 		Column4: untilTS,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1018,7 +1018,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "last_heard_at epoch ms of last item for pagination",
+                        "description": "epoch ms of last item for pagination; last_heard_at, or site-local heard_at when iatas is set",
                         "name": "cursor",
                         "in": "query"
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1016,7 +1016,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "last_heard_at epoch ms of last item for pagination",
+                        "description": "epoch ms of last item for pagination; last_heard_at, or site-local heard_at when iatas is set",
                         "name": "cursor",
                         "in": "query"
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1675,7 +1675,8 @@ paths:
         in: query
         name: until
         type: integer
-      - description: last_heard_at epoch ms of last item for pagination
+      - description: epoch ms of last item for pagination; last_heard_at, or site-local
+          heard_at when iatas is set
         in: query
         name: cursor
         type: integer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MeshCore-Beacon/beacon-server
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/internal/api/handlers/packets.go
+++ b/internal/api/handlers/packets.go
@@ -41,7 +41,7 @@ func PacketsRouter(reader api.Reader) http.Handler {
 //	@Param		region			query		string	false	"Filter by region slug, expands to member IATAs"
 //	@Param		since			query		int		false	"Filter by first_heard_at >= since (epoch ms)"
 //	@Param		until			query		int		false	"Filter by first_heard_at <= until (epoch ms)"
-//	@Param		cursor			query		int		false	"last_heard_at epoch ms of last item for pagination"
+//	@Param		cursor			query		int		false	"epoch ms of last item for pagination; last_heard_at, or site-local heard_at when iatas is set"
 //	@Param		limit			query		int		false	"Max results (default 50)"
 //	@Success	200				{object}	object
 //	@Failure	400				{object}	handlers.APIError

--- a/internal/api/reader.go
+++ b/internal/api/reader.go
@@ -116,7 +116,9 @@ type Reader interface {
 	// ListPackets returns a paginated list of packets with the latest observation rolled in.
 	// Pass 0 for payloadType/routeType to skip those filters.
 	// Pass nil for iatas, zero times for since/until to skip those filters.
-	// cursor is last_heard_at epoch ms; pass 0 to start from the beginning.
+	// Unfiltered lists order by global last_heard_at; when iatas are set, ordering
+	// and the cursor are site-local (heard_at at the requested sites) instead.
+	// cursor is epoch ms in either case; pass 0 to start from the beginning.
 	ListPackets(ctx context.Context, payloadType, routeType int16, iatas []string, scope string, since, until time.Time, cursor int64, limit int32) (Page[PacketSummary], error)
 
 	// ListPacketsAfterID returns packets with observations after the given observation ID,

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -20,3 +20,5 @@ sql:
             go_type: "github.com/google/uuid.UUID"
           - db_type: "jsonb"
             go_type: "encoding/json.RawMessage"
+          - db_type: "bpchar"
+            go_type: "string"


### PR DESCRIPTION
Closes #80

One commit per fix from the issue:

- **Index on `packets(last_heard_at)`.** The packet list sorts by it, so every page was a seq scan plus disk sort over all packets. Worth noting the same relationship the issue did: this index is cheap to maintain once #82's presence coalescing lands, since the column stops being rewritten per packet.
- **IATA filters as `bpchar[]`.** `string_to_array` produced a `text[]` compared against `CHAR(3)`, which blocked the iata indexes and hid the values from the planner. Applied to all 17 queries carrying the pattern — channels, stats, nodes, observers and traces shared it, which is why those endpoints crawled too. Handlers already had a `[]string`; the store layer just stops joining to CSV. Includes a small sqlc override so array params generate `[]string`.
- **IATA-filtered packet lists walk `idx_observations_iata_heard`.** Instead of scanning packets newest-first and probing each one for the requested site (~589k probes to fill a page for a quiet site), the query walks each requested site's own observation log and dedups. Behavior change to be aware of: filtered lists now order by when the requested sites heard the packet (site-local recency) and the cursor follows — swagger and the reader docs are updated. Pagination assigns each packet to the page of its newest qualifying observation, so packets don't repeat across pages.

Measured on the meshmapper instance (PG16, ~1.5M packets, ~13.5M observations): unfiltered list 2.8s → 31ms, and a 13-IATA filter that ranged 2.5–20s under load now returns in 44ms.

Last commit is the same go 1.26.5 bump as #82/#83 so govulncheck passes here; it merges as a no-op once either of those lands.