### PR TITLE
perf: fix the payload-breakdown 500 and slow top-observers on the analytics tab

### DIFF
--- a/db/channels.go
+++ b/db/channels.go
@@ -47,16 +47,28 @@ func (s *Store) UpsertChannelHashOnly(ctx context.Context, channelHash []byte) (
 	return int(rowID), nil
 }
 
-func (s *Store) ListChannels(ctx context.Context, limit int32, hash []byte, iata string, cursor int64) (api.Page[api.ChannelSummary], error) {
+func (s *Store) UpsertChannelIATA(ctx context.Context, channelHash []byte, iata string, heardAt time.Time) error {
+	return s.q.UpsertChannelIATA(ctx, sqlc.UpsertChannelIATAParams{
+		ChannelHash: channelHash,
+		Iata:        iata,
+		LastHeard:   pgtype.Timestamptz{Time: heardAt, Valid: true},
+	})
+}
+
+func (s *Store) DeleteOldChannelIATAs(ctx context.Context, cutoff time.Time) error {
+	return s.q.DeleteOldChannelIATAs(ctx, pgtype.Timestamptz{Time: cutoff, Valid: true})
+}
+
+func (s *Store) ListChannels(ctx context.Context, limit int32, hash []byte, iatas []string, cursor int64) (api.Page[api.ChannelSummary], error) {
 	var cursorTS pgtype.Timestamptz
 	if cursor > 0 {
 		cursorTS = pgtype.Timestamptz{Time: time.UnixMilli(cursor), Valid: true}
 	}
 	rows, err := s.q.ListChannels(ctx, sqlc.ListChannelsParams{
-		Column1: hash,
-		Column2: iata,
-		Column3: cursorTS,
-		Limit:   limit + 1,
+		ChannelHash: hash,
+		Iatas:       iatas,
+		CursorTs:    cursorTS,
+		PageLimit:   limit + 1,
 	})
 	if err != nil {
 		return api.Page[api.ChannelSummary]{}, err

--- a/db/channels_test.go
+++ b/db/channels_test.go
@@ -21,15 +21,15 @@ func TestListChannels_Empty(t *testing.T) {
 
 	mock.EXPECT().
 		ListChannels(gomock.Any(), sqlc.ListChannelsParams{
-			Column1: nil,
-			Column2: "",
-			Column3: pgtype.Timestamptz{},
-			Limit:   11,
+			ChannelHash: nil,
+			Iatas:       nil,
+			CursorTs:    pgtype.Timestamptz{},
+			PageLimit:   11,
 		}).
 		Return([]sqlc.Channel{}, nil)
 
 	store := &Store{q: mock}
-	page, err := store.ListChannels(context.Background(), 10, nil, "", 0)
+	page, err := store.ListChannels(context.Background(), 10, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -63,15 +63,15 @@ func TestListChannels_Pagination(t *testing.T) {
 
 	mock.EXPECT().
 		ListChannels(gomock.Any(), sqlc.ListChannelsParams{
-			Column1: nil,
-			Column2: "",
-			Column3: pgtype.Timestamptz{},
-			Limit:   3, // limit+1
+			ChannelHash: nil,
+			Iatas:       nil,
+			CursorTs:    pgtype.Timestamptz{},
+			PageLimit:   3, // limit+1
 		}).
 		Return(rows, nil)
 
 	store := &Store{q: mock}
-	page, err := store.ListChannels(context.Background(), 2, nil, "", 0)
+	page, err := store.ListChannels(context.Background(), 2, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,9 +95,29 @@ func TestListChannels_DBError(t *testing.T) {
 		Return(nil, errors.New("db error"))
 
 	store := &Store{q: mock}
-	_, err := store.ListChannels(context.Background(), 10, nil, "", 0)
+	_, err := store.ListChannels(context.Background(), 10, nil, nil, 0)
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestListChannels_IATAFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := mockdb.NewMockQuerier(ctrl)
+
+	mock.EXPECT().
+		ListChannels(gomock.Any(), sqlc.ListChannelsParams{
+			ChannelHash: nil,
+			Iatas:       []string{"YOW", "YYZ"},
+			CursorTs:    pgtype.Timestamptz{},
+			PageLimit:   11,
+		}).
+		Return([]sqlc.Channel{}, nil)
+
+	store := &Store{q: mock}
+	_, err := store.ListChannels(context.Background(), 10, nil, []string{"YOW", "YYZ"}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/db/migrations/011_channel_iatas.sql
+++ b/db/migrations/011_channel_iatas.sql
@@ -1,0 +1,19 @@
+-- Per-IATA channel activity so the IATA filter skips the ~7s EXISTS over packets.
+-- Keyed by raw hash (channels can share one), so no FK to channels.
+
+CREATE TABLE channel_iatas (
+  channel_hash BYTEA NOT NULL,
+  iata         CHAR(3) NOT NULL REFERENCES iata_codes(iata) ON DELETE CASCADE,
+  last_heard   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (channel_hash, iata)
+);
+
+CREATE INDEX idx_channel_iatas_iata ON channel_iatas(iata, last_heard DESC);
+
+-- Seed from retained packets so the filter works right away.
+INSERT INTO channel_iatas (channel_hash, iata, last_heard)
+SELECT p.channel_hash, po.iata, MAX(po.heard_at)
+FROM packets p
+JOIN packet_observations po ON po.packet_hash = p.packet_hash
+WHERE p.channel_hash IS NOT NULL
+GROUP BY p.channel_hash, po.iata;

--- a/db/migrations/011_channel_iatas.sql
+++ b/db/migrations/011_channel_iatas.sql
@@ -8,12 +8,16 @@ CREATE TABLE channel_iatas (
   PRIMARY KEY (channel_hash, iata)
 );
 
-CREATE INDEX idx_channel_iatas_iata ON channel_iatas(iata, last_heard DESC);
+CREATE INDEX idx_channel_iatas_iata ON channel_iatas(iata);
 
--- Seed from retained packets so the filter works right away.
+-- Seed from retained packets; parallelism off so the join spills to disk, not /dev/shm.
+SET max_parallel_workers_per_gather = 0;
+
 INSERT INTO channel_iatas (channel_hash, iata, last_heard)
 SELECT p.channel_hash, po.iata, MAX(po.heard_at)
 FROM packets p
 JOIN packet_observations po ON po.packet_hash = p.packet_hash
 WHERE p.channel_hash IS NOT NULL
 GROUP BY p.channel_hash, po.iata;
+
+RESET max_parallel_workers_per_gather;

--- a/db/migrations/012_trace_iatas.sql
+++ b/db/migrations/012_trace_iatas.sql
@@ -1,0 +1,23 @@
+-- Per-IATA trace activity so the trace filter stops joining every trace packet
+-- to observations (the hash join was overrunning /dev/shm).
+
+CREATE TABLE trace_iatas (
+  trace_tag  BYTEA NOT NULL,
+  iata       CHAR(3) NOT NULL REFERENCES iata_codes(iata) ON DELETE CASCADE,
+  last_heard TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (trace_tag, iata)
+);
+
+CREATE INDEX idx_trace_iatas_iata ON trace_iatas(iata, last_heard DESC);
+
+-- Seed from retained packets; parallelism off so the join spills to disk, not /dev/shm.
+SET max_parallel_workers_per_gather = 0;
+
+INSERT INTO trace_iatas (trace_tag, iata, last_heard)
+SELECT p.trace_tag, po.iata, MAX(po.heard_at)
+FROM packets p
+JOIN packet_observations po ON po.packet_hash = p.packet_hash
+WHERE p.trace_tag IS NOT NULL
+GROUP BY p.trace_tag, po.iata;
+
+RESET max_parallel_workers_per_gather;

--- a/db/migrations/012_trace_iatas.sql
+++ b/db/migrations/012_trace_iatas.sql
@@ -8,7 +8,7 @@ CREATE TABLE trace_iatas (
   PRIMARY KEY (trace_tag, iata)
 );
 
-CREATE INDEX idx_trace_iatas_iata ON trace_iatas(iata, last_heard DESC);
+CREATE INDEX idx_trace_iatas_iata ON trace_iatas(iata);
 
 -- Seed from retained packets; parallelism off so the join spills to disk, not /dev/shm.
 SET max_parallel_workers_per_gather = 0;

--- a/db/migrations/013_packets_scope_index.sql
+++ b/db/migrations/013_packets_scope_index.sql
@@ -1,0 +1,3 @@
+-- Scope stats count off scope_id, which had no index.
+
+CREATE INDEX idx_packets_scope ON packets(scope_id) WHERE scope_id IS NOT NULL;

--- a/db/migrations/014_known_routes_last_seen_index.sql
+++ b/db/migrations/014_known_routes_last_seen_index.sql
@@ -1,0 +1,3 @@
+-- Routes list orders by last_seen; index it (was seq-scanning ~150k rows per page).
+
+CREATE INDEX idx_known_routes_last_seen ON known_routes(last_seen DESC);

--- a/db/migrations/015_observations_payload_type.sql
+++ b/db/migrations/015_observations_payload_type.sql
@@ -1,0 +1,17 @@
+-- Copy payload_type onto the observation (like source_broker) so the breakdown
+-- drops its join back to packets, which was overrunning /dev/shm and 500ing.
+
+ALTER TABLE packet_observations ADD COLUMN payload_type SMALLINT;
+
+-- Backfill the last 7 days only (all the breakdown reads); parallelism off so
+-- the join spills to disk, not /dev/shm.
+SET max_parallel_workers_per_gather = 0;
+
+UPDATE packet_observations po
+SET payload_type = p.payload_type
+FROM packets p
+WHERE p.packet_hash = po.packet_hash
+  AND po.heard_at > NOW() - INTERVAL '7 days'
+  AND po.payload_type IS NULL;
+
+RESET max_parallel_workers_per_gather;

--- a/db/migrations/016_mv_payload_breakdown.sql
+++ b/db/migrations/016_mv_payload_breakdown.sql
@@ -1,0 +1,15 @@
+-- Precomputed payload breakdown so the request reads a small table instead of
+-- scanning a week of observations.
+
+CREATE MATERIALIZED VIEW mv_payload_breakdown_by_iata AS
+SELECT
+  iata,
+  payload_type,
+  COUNT(*) AS count
+FROM packet_observations
+WHERE heard_at > NOW() - INTERVAL '7 days'
+  AND payload_type IS NOT NULL
+GROUP BY iata, payload_type;
+
+CREATE UNIQUE INDEX idx_mv_payload_breakdown
+  ON mv_payload_breakdown_by_iata(iata, payload_type);

--- a/db/migrations/017_mv_top_observers.sql
+++ b/db/migrations/017_mv_top_observers.sql
@@ -1,0 +1,18 @@
+-- Precomputed top observers, same shape as mv_top_nodes_by_iata (was a ~2s
+-- per-request scan of a week of observations).
+
+CREATE MATERIALIZED VIEW mv_top_observers_by_iata AS
+SELECT
+  po.iata,
+  po.observer_id,
+  o.display_name,
+  o.observer_type,
+  COUNT(*) AS observation_count,
+  MAX(po.heard_at) AS last_heard
+FROM packet_observations po
+JOIN observers o ON o.id = po.observer_id
+WHERE po.heard_at > NOW() - INTERVAL '7 days'
+GROUP BY po.iata, po.observer_id, o.display_name, o.observer_type;
+
+CREATE UNIQUE INDEX idx_mv_top_observers
+  ON mv_top_observers_by_iata(iata, observer_id);

--- a/db/packets.go
+++ b/db/packets.go
@@ -505,6 +505,7 @@ func (s *Store) InsertObservation(ctx context.Context, o ingest.InsertObservatio
 		BandwidthKhz:      &o.BandwidthKHz,
 		CodingRate:        &o.CodingRate,
 		SourceBroker:      &o.SourceBroker,
+		PayloadType:       &o.PayloadType,
 	}
 	row, err := s.q.InsertObservation(ctx, params)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -498,6 +498,10 @@ DELETE FROM packets WHERE last_heard_at < $1;
 -- Keeps the channel IATA filter in step with packet retention.
 DELETE FROM channel_iatas WHERE last_heard < $1;
 
+-- name: DeleteOldTraceIATAs :exec
+-- Keeps the trace IATA filter in step with packet retention.
+DELETE FROM trace_iatas WHERE last_heard < $1;
+
 -- ============================================================
 -- PACKET OBSERVATIONS
 -- ============================================================
@@ -678,6 +682,12 @@ VALUES ($1, $2, $3)
 ON CONFLICT (channel_hash, iata) DO UPDATE SET
   last_heard = EXCLUDED.last_heard
 WHERE EXCLUDED.last_heard > channel_iatas.last_heard + INTERVAL '1 hour';
+
+-- name: UpsertTraceIATA :exec
+INSERT INTO trace_iatas (trace_tag, iata, last_heard)
+VALUES ($1, $2, $3)
+ON CONFLICT (trace_tag, iata) DO UPDATE SET
+  last_heard = GREATEST(trace_iatas.last_heard, EXCLUDED.last_heard);
 
 -- name: ListChannels :many
 -- Channels ordered by last seen, optionally filtered by hash and/or IATAs
@@ -965,33 +975,45 @@ ON CONFLICT (region_id, iata) DO NOTHING;
 
 -- name: ListTraceTags :many
 -- Returns distinct trace tags with summary info, ordered by most recent first.
+-- IATA membership comes from trace_iatas (joining observations here spilled the
+-- hash join). Per-tag details filled in only for the returned page.
+WITH tags AS (
+    SELECT
+        p.trace_tag,
+        MIN(p.first_heard_at) AS first_heard_at,
+        MAX(p.last_heard_at) AS last_heard_at,
+        COUNT(*) AS packet_count,
+        MAX(p.parsed_payload->>'type') AS trace_type
+    FROM packets p
+    WHERE p.trace_tag IS NOT NULL
+      AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR p.trace_tag IN (
+          SELECT ti.trace_tag FROM trace_iatas ti WHERE ti.iata = ANY($1::bpchar[])))
+      AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
+      AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
+      AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
+      AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
+      AND ($7::text = '' OR p.parsed_payload->>'type' = $7)
+    GROUP BY p.trace_tag
+    ORDER BY MAX(p.last_heard_at) DESC
+    LIMIT $6
+)
 SELECT
-    encode(p.trace_tag, 'hex') AS trace_tag,
-    MIN(p.first_heard_at)::timestamptz AS first_heard_at,
-    MAX(p.last_heard_at)::timestamptz AS last_heard_at,
-    COUNT(DISTINCT p.packet_hash) AS packet_count,
-    COUNT(DISTINCT po.iata) AS iata_count,
-    MAX(p.parsed_payload->>'type')::text AS trace_type,
-    best.parsed_payload AS best_payload
-FROM packets p
-LEFT JOIN packet_observations po ON po.packet_hash = p.packet_hash
-LEFT JOIN LATERAL (
-    SELECT parsed_payload
-    FROM packets p2
-    WHERE p2.trace_tag = p.trace_tag
-    ORDER BY jsonb_array_length(p2.parsed_payload->'pathHashes') DESC
-    LIMIT 1
-) best ON true
-WHERE p.trace_tag IS NOT NULL
-  AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
-  AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
-  AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
-  AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
-  AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
-  AND ($7::text = '' OR p.parsed_payload->>'type' = $7)
-GROUP BY p.trace_tag, best.parsed_payload
-ORDER BY MAX(p.last_heard_at) DESC
-LIMIT $6;
+    encode(t.trace_tag, 'hex') AS trace_tag,
+    t.first_heard_at::timestamptz AS first_heard_at,
+    t.last_heard_at::timestamptz AS last_heard_at,
+    t.packet_count,
+    (SELECT COUNT(*)
+     FROM trace_iatas ti
+     WHERE ti.trace_tag = t.trace_tag
+       AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR ti.iata = ANY($1::bpchar[]))) AS iata_count,
+    t.trace_type::text AS trace_type,
+    (SELECT p3.parsed_payload
+     FROM packets p3
+     WHERE p3.trace_tag = t.trace_tag
+     ORDER BY jsonb_array_length(p3.parsed_payload->'pathHashes') DESC
+     LIMIT 1) AS best_payload
+FROM tags t
+ORDER BY t.last_heard_at DESC;
 
 -- ============================================================
 -- ROUTES

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -523,9 +523,10 @@ INSERT INTO packet_observations (
   spread_factor,
   bandwidth_khz,
   coding_rate,
-  source_broker
+  source_broker,
+  payload_type
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
 )
 ON CONFLICT (packet_hash, observer_id) DO NOTHING
 RETURNING *;
@@ -821,15 +822,13 @@ ORDER BY observation_count DESC
 LIMIT $2;
 
 -- name: GetStatsPayloadBreakdown :many
--- Returns observation counts grouped by payload type for the given window and IATA.
+-- Payload-type counts for the IATA, from the precomputed view.
 SELECT
-  p.payload_type,
-  COUNT(*) AS count
-FROM packet_observations po
-JOIN packets p ON p.packet_hash = po.packet_hash
-WHERE po.heard_at > $1
-  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
-GROUP BY p.payload_type
+  payload_type,
+  SUM(count)::bigint AS count
+FROM mv_payload_breakdown_by_iata
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR iata = ANY($1::bpchar[]))
+GROUP BY payload_type
 ORDER BY count DESC;
 
 -- name: GetStatsNodeTypes :many
@@ -1140,6 +1139,9 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY mv_hourly_iata_stats;
 
 -- name: RefreshTopNodes :exec
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_nodes_by_iata;
+
+-- name: RefreshPayloadBreakdown :exec
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_payload_breakdown_by_iata;
 
 -- name: RefreshRadioPresets :exec
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_radio_presets;

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -494,6 +494,10 @@ LIMIT $6;
 -- packet_observations cascade-delete via FK.
 DELETE FROM packets WHERE last_heard_at < $1;
 
+-- name: DeleteOldChannelIATAs :exec
+-- Keeps the channel IATA filter in step with packet retention.
+DELETE FROM channel_iatas WHERE last_heard < $1;
+
 -- ============================================================
 -- PACKET OBSERVATIONS
 -- ============================================================
@@ -667,22 +671,25 @@ ON CONFLICT (channel_hash) WHERE key_fingerprint IS NULL DO UPDATE SET
   last_seen = NOW()
 RETURNING id;
 
+-- name: UpsertChannelIATA :exec
+INSERT INTO channel_iatas (channel_hash, iata, last_heard)
+VALUES ($1, $2, $3)
+ON CONFLICT (channel_hash, iata) DO UPDATE SET
+  last_heard = GREATEST(channel_iatas.last_heard, EXCLUDED.last_heard);
+
 -- name: ListChannels :many
--- Returns channels ordered by last seen, optionally filtered by hash and/or IATA.
--- Pass NULL for hash to skip hash filtering. Pass empty string for iata to skip IATA filtering.
--- IATA filter returns channels that have active packets in that IATA (case-insensitive).
+-- Channels ordered by last seen, optionally filtered by hash and/or IATAs
+-- (membership via channel_iatas). NULL hash / empty array skip those filters.
 -- Pass cursor=0 to start from the beginning (cursor is last_seen epoch ms).
-SELECT DISTINCT c.* FROM channels c
-WHERE ($1::bytea IS NULL OR c.channel_hash = $1)
-  AND ($2 = '' OR EXISTS (
-    SELECT 1 FROM packets p
-    JOIN packet_observations po ON po.packet_hash = p.packet_hash
-    WHERE p.channel_hash = c.channel_hash
-      AND po.iata ILIKE $2
+SELECT c.* FROM channels c
+WHERE (@channel_hash::bytea IS NULL OR c.channel_hash = @channel_hash)
+  AND (COALESCE(cardinality(@iatas::bpchar[]), 0) = 0 OR c.channel_hash IN (
+    SELECT ci.channel_hash FROM channel_iatas ci
+    WHERE ci.iata = ANY(@iatas::bpchar[])
   ))
-  AND ($3::timestamptz IS NULL OR c.last_seen < $3)
+  AND (@cursor_ts::timestamptz IS NULL OR c.last_seen < @cursor_ts)
 ORDER BY c.last_seen DESC
-LIMIT $4;
+LIMIT @page_limit;
 
 -- name: GetChannelByID :one
 SELECT * FROM channels WHERE id = $1;

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -843,22 +843,18 @@ GROUP BY n.node_type
 ORDER BY count DESC;
 
 -- name: GetStatsTopObservers :many
--- Returns the top N observers by observation count for the given window and IATA.
+-- Top N observers for the IATA, from the precomputed view. Counts sum across
+-- matched IATAs; iata is a representative one for display.
 SELECT
-  o.id,
-  o.display_name,
-  o.observer_type,
-  COUNT(*) AS observation_count,
-  COALESCE((
-    SELECT po2.iata FROM packet_observations po2
-    WHERE po2.observer_id = o.id
-    ORDER BY po2.heard_at DESC LIMIT 1
-  ), '') AS iata
-FROM packet_observations po
-JOIN observers o ON o.id = po.observer_id
-WHERE po.heard_at > $1
-  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
-GROUP BY o.id
+  observer_id AS id,
+  display_name,
+  observer_type,
+  COALESCE(SUM(observation_count), 0)::bigint AS observation_count,
+  COALESCE(MAX(iata), '')::bpchar AS iata
+FROM mv_top_observers_by_iata
+WHERE last_heard > $1
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR iata = ANY($2::bpchar[]))
+GROUP BY observer_id, display_name, observer_type
 ORDER BY observation_count DESC
 LIMIT $3;
 
@@ -1139,6 +1135,9 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY mv_hourly_iata_stats;
 
 -- name: RefreshTopNodes :exec
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_nodes_by_iata;
+
+-- name: RefreshTopObservers :exec
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_observers_by_iata;
 
 -- name: RefreshPayloadBreakdown :exec
 REFRESH MATERIALIZED VIEW CONCURRENTLY mv_payload_breakdown_by_iata;

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -672,10 +672,12 @@ ON CONFLICT (channel_hash) WHERE key_fingerprint IS NULL DO UPDATE SET
 RETURNING id;
 
 -- name: UpsertChannelIATA :exec
+-- Refreshes at most hourly so repeat hears don't churn the row.
 INSERT INTO channel_iatas (channel_hash, iata, last_heard)
 VALUES ($1, $2, $3)
 ON CONFLICT (channel_hash, iata) DO UPDATE SET
-  last_heard = GREATEST(channel_iatas.last_heard, EXCLUDED.last_heard);
+  last_heard = EXCLUDED.last_heard
+WHERE EXCLUDED.last_heard > channel_iatas.last_heard + INTERVAL '1 hour';
 
 -- name: ListChannels :many
 -- Channels ordered by last seen, optionally filtered by hash and/or IATAs

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -684,10 +684,12 @@ ON CONFLICT (channel_hash, iata) DO UPDATE SET
 WHERE EXCLUDED.last_heard > channel_iatas.last_heard + INTERVAL '1 hour';
 
 -- name: UpsertTraceIATA :exec
+-- Refreshes at most hourly so repeat hears don't churn the row.
 INSERT INTO trace_iatas (trace_tag, iata, last_heard)
 VALUES ($1, $2, $3)
 ON CONFLICT (trace_tag, iata) DO UPDATE SET
-  last_heard = GREATEST(trace_iatas.last_heard, EXCLUDED.last_heard);
+  last_heard = EXCLUDED.last_heard
+WHERE EXCLUDED.last_heard > trace_iatas.last_heard + INTERVAL '1 hour';
 
 -- name: ListChannels :many
 -- Channels ordered by last seen, optionally filtered by hash and/or IATAs

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -917,16 +917,14 @@ WHERE ($1::text = '' OR preset = $1::text)
 ORDER BY preset, iata, source_type;
 
 -- name: GetScopeStats :many
+-- Count each table on its own; the old cross-join blew up to millions of rows
+-- before COUNT(DISTINCT) (~10s).
 SELECT
     ts.name,
-    COUNT(DISTINCT p.packet_hash) AS packet_count,
-    COUNT(DISTINCT os.observer_id) AS observer_count,
-    COUNT(DISTINCT n.id) AS node_count
+    (SELECT COUNT(*) FROM packets p WHERE p.scope_id = ts.id) AS packet_count,
+    (SELECT COUNT(*) FROM observer_scopes os WHERE os.scope_id = ts.id) AS observer_count,
+    (SELECT COUNT(*) FROM nodes n WHERE n.default_scope_id = ts.id) AS node_count
 FROM transport_scopes ts
-LEFT JOIN packets p ON p.scope_id = ts.id
-LEFT JOIN observer_scopes os ON os.scope_id = ts.id
-LEFT JOIN nodes n ON n.default_scope_id = ts.id
-GROUP BY ts.name
 ORDER BY ts.name;
 
 -- ============================================================

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -85,6 +85,20 @@ func (mr *MockQuerierMockRecorder) DeleteOldTelemetry(ctx, reportedAt any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldTelemetry", reflect.TypeOf((*MockQuerier)(nil).DeleteOldTelemetry), ctx, reportedAt)
 }
 
+// DeleteOldTraceIATAs mocks base method.
+func (m *MockQuerier) DeleteOldTraceIATAs(ctx context.Context, lastHeard pgtype.Timestamptz) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOldTraceIATAs", ctx, lastHeard)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOldTraceIATAs indicates an expected call of DeleteOldTraceIATAs.
+func (mr *MockQuerierMockRecorder) DeleteOldTraceIATAs(ctx, lastHeard any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldTraceIATAs", reflect.TypeOf((*MockQuerier)(nil).DeleteOldTraceIATAs), ctx, lastHeard)
+}
+
 // GetChannelByID mocks base method.
 func (m *MockQuerier) GetChannelByID(ctx context.Context, id int32) (db.Channel, error) {
 	m.ctrl.T.Helper()
@@ -1425,6 +1439,20 @@ func (m *MockQuerier) UpsertRegionIATA(ctx context.Context, arg db.UpsertRegionI
 func (mr *MockQuerierMockRecorder) UpsertRegionIATA(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRegionIATA", reflect.TypeOf((*MockQuerier)(nil).UpsertRegionIATA), ctx, arg)
+}
+
+// UpsertTraceIATA mocks base method.
+func (m *MockQuerier) UpsertTraceIATA(ctx context.Context, arg db.UpsertTraceIATAParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertTraceIATA", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertTraceIATA indicates an expected call of UpsertTraceIATA.
+func (mr *MockQuerierMockRecorder) UpsertTraceIATA(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTraceIATA", reflect.TypeOf((*MockQuerier)(nil).UpsertTraceIATA), ctx, arg)
 }
 
 // UpsertTransportScope mocks base method.

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -550,18 +550,18 @@ func (mr *MockQuerierMockRecorder) GetStatsOverview(ctx, dollar_1 any) *gomock.C
 }
 
 // GetStatsPayloadBreakdown mocks base method.
-func (m *MockQuerier) GetStatsPayloadBreakdown(ctx context.Context, arg db.GetStatsPayloadBreakdownParams) ([]db.GetStatsPayloadBreakdownRow, error) {
+func (m *MockQuerier) GetStatsPayloadBreakdown(ctx context.Context, dollar_1 []string) ([]db.GetStatsPayloadBreakdownRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStatsPayloadBreakdown", ctx, arg)
+	ret := m.ctrl.Call(m, "GetStatsPayloadBreakdown", ctx, dollar_1)
 	ret0, _ := ret[0].([]db.GetStatsPayloadBreakdownRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStatsPayloadBreakdown indicates an expected call of GetStatsPayloadBreakdown.
-func (mr *MockQuerierMockRecorder) GetStatsPayloadBreakdown(ctx, arg any) *gomock.Call {
+func (mr *MockQuerierMockRecorder) GetStatsPayloadBreakdown(ctx, dollar_1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatsPayloadBreakdown", reflect.TypeOf((*MockQuerier)(nil).GetStatsPayloadBreakdown), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatsPayloadBreakdown", reflect.TypeOf((*MockQuerier)(nil).GetStatsPayloadBreakdown), ctx, dollar_1)
 }
 
 // GetStatsTopAdvertisers mocks base method.
@@ -993,6 +993,20 @@ func (m *MockQuerier) RefreshHourlyStats(ctx context.Context) error {
 func (mr *MockQuerierMockRecorder) RefreshHourlyStats(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshHourlyStats", reflect.TypeOf((*MockQuerier)(nil).RefreshHourlyStats), ctx)
+}
+
+// RefreshPayloadBreakdown mocks base method.
+func (m *MockQuerier) RefreshPayloadBreakdown(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshPayloadBreakdown", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshPayloadBreakdown indicates an expected call of RefreshPayloadBreakdown.
+func (mr *MockQuerierMockRecorder) RefreshPayloadBreakdown(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshPayloadBreakdown", reflect.TypeOf((*MockQuerier)(nil).RefreshPayloadBreakdown), ctx)
 }
 
 // RefreshRadioPresets mocks base method.

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -1037,6 +1037,20 @@ func (mr *MockQuerierMockRecorder) RefreshTopNodes(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTopNodes", reflect.TypeOf((*MockQuerier)(nil).RefreshTopNodes), ctx)
 }
 
+// RefreshTopObservers mocks base method.
+func (m *MockQuerier) RefreshTopObservers(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshTopObservers", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshTopObservers indicates an expected call of RefreshTopObservers.
+func (mr *MockQuerierMockRecorder) RefreshTopObservers(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTopObservers", reflect.TypeOf((*MockQuerier)(nil).RefreshTopObservers), ctx)
+}
+
 // ResolvePathHashesP1 mocks base method.
 func (m *MockQuerier) ResolvePathHashesP1(ctx context.Context, arg db.ResolvePathHashesP1Params) ([]db.ResolvePathHashesP1Row, error) {
 	m.ctrl.T.Helper()

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -43,6 +43,20 @@ func (m *MockQuerier) EXPECT() *MockQuerierMockRecorder {
 	return m.recorder
 }
 
+// DeleteOldChannelIATAs mocks base method.
+func (m *MockQuerier) DeleteOldChannelIATAs(ctx context.Context, lastHeard pgtype.Timestamptz) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOldChannelIATAs", ctx, lastHeard)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOldChannelIATAs indicates an expected call of DeleteOldChannelIATAs.
+func (mr *MockQuerierMockRecorder) DeleteOldChannelIATAs(ctx, lastHeard any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldChannelIATAs", reflect.TypeOf((*MockQuerier)(nil).DeleteOldChannelIATAs), ctx, lastHeard)
+}
+
 // DeleteOldPackets mocks base method.
 func (m *MockQuerier) DeleteOldPackets(ctx context.Context, lastHeardAt pgtype.Timestamptz) error {
 	m.ctrl.T.Helper()
@@ -1211,6 +1225,20 @@ func (m *MockQuerier) UpsertChannelHashOnly(ctx context.Context, channelHash []b
 func (mr *MockQuerierMockRecorder) UpsertChannelHashOnly(ctx, channelHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChannelHashOnly", reflect.TypeOf((*MockQuerier)(nil).UpsertChannelHashOnly), ctx, channelHash)
+}
+
+// UpsertChannelIATA mocks base method.
+func (m *MockQuerier) UpsertChannelIATA(ctx context.Context, arg db.UpsertChannelIATAParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertChannelIATA", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertChannelIATA indicates an expected call of UpsertChannelIATA.
+func (mr *MockQuerierMockRecorder) UpsertChannelIATA(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChannelIATA", reflect.TypeOf((*MockQuerier)(nil).UpsertChannelIATA), ctx, arg)
 }
 
 // UpsertIATA mocks base method.

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -74,6 +74,12 @@ type MvHourlyIataStat struct {
 	ActiveObservers  int64              `json:"active_observers"`
 }
 
+type MvPayloadBreakdownByIatum struct {
+	Iata        string `json:"iata"`
+	PayloadType *int16 `json:"payload_type"`
+	Count       int64  `json:"count"`
+}
+
 type MvRadioPreset struct {
 	Preset     string `json:"preset"`
 	Iata       string `json:"iata"`
@@ -250,6 +256,7 @@ type PacketObservation struct {
 	BandwidthKhz      *float32           `json:"bandwidth_khz"`
 	CodingRate        *int16             `json:"coding_rate"`
 	SourceBroker      *string            `json:"source_broker"`
+	PayloadType       *int16             `json:"payload_type"`
 }
 
 type Region struct {

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -23,6 +23,12 @@ type Channel struct {
 	MessageCount   *int64             `json:"message_count"`
 }
 
+type ChannelIata struct {
+	ChannelHash []byte             `json:"channel_hash"`
+	Iata        string             `json:"iata"`
+	LastHeard   pgtype.Timestamptz `json:"last_heard"`
+}
+
 type ChannelKey struct {
 	ChannelID      int32              `json:"channel_id"`
 	KeyBytes       []byte             `json:"key_bytes"`

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -271,6 +271,12 @@ type RegionIata struct {
 	AddedAt  pgtype.Timestamptz `json:"added_at"`
 }
 
+type TraceIata struct {
+	TraceTag  []byte             `json:"trace_tag"`
+	Iata      string             `json:"iata"`
+	LastHeard pgtype.Timestamptz `json:"last_heard"`
+}
+
 type TransportScope struct {
 	ID             int32              `json:"id"`
 	Name           string             `json:"name"`

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -96,6 +96,15 @@ type MvTopNodesByIatum struct {
 	LastHeard        pgtype.Timestamptz `json:"last_heard"`
 }
 
+type MvTopObserversByIatum struct {
+	Iata             string      `json:"iata"`
+	ObserverID       uuid.UUID   `json:"observer_id"`
+	DisplayName      *string     `json:"display_name"`
+	ObserverType     *string     `json:"observer_type"`
+	ObservationCount int64       `json:"observation_count"`
+	LastHeard        interface{} `json:"last_heard"`
+}
+
 type Node struct {
 	ID                      uuid.UUID          `json:"id"`
 	PublicKey               []byte             `json:"public_key"`

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -60,8 +60,8 @@ type Querier interface {
 	// STATS
 	// ============================================================
 	GetStatsOverview(ctx context.Context, dollar_1 []string) (GetStatsOverviewRow, error)
-	// Returns observation counts grouped by payload type for the given window and IATA.
-	GetStatsPayloadBreakdown(ctx context.Context, arg GetStatsPayloadBreakdownParams) ([]GetStatsPayloadBreakdownRow, error)
+	// Payload-type counts for the IATA, from the precomputed view.
+	GetStatsPayloadBreakdown(ctx context.Context, dollar_1 []string) ([]GetStatsPayloadBreakdownRow, error)
 	// Returns the top N nodes by distinct ADVERT packet count for the given window and IATA.
 	// COUNT(DISTINCT p.packet_hash) rather than COUNT(*): the same advert broadcast is commonly
 	// heard by more than one observer, and each hearing is its own packet_observations row --
@@ -156,6 +156,7 @@ type Querier interface {
 	// that IATA, or where any hop's prefix_4 is now ambiguous (matches >1 node).
 	ReconfirmRoutes(ctx context.Context) error
 	RefreshHourlyStats(ctx context.Context) error
+	RefreshPayloadBreakdown(ctx context.Context) error
 	RefreshRadioPresets(ctx context.Context) error
 	RefreshTopNodes(ctx context.Context) error
 	// ============================================================

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -67,7 +67,8 @@ type Querier interface {
 	// heard by more than one observer, and each hearing is its own packet_observations row --
 	// this counts adverts sent, not adverts heard.
 	GetStatsTopAdvertisers(ctx context.Context, arg GetStatsTopAdvertisersParams) ([]GetStatsTopAdvertisersRow, error)
-	// Returns the top N observers by observation count for the given window and IATA.
+	// Top N observers for the IATA, from the precomputed view. Counts sum across
+	// matched IATAs; iata is a representative one for display.
 	GetStatsTopObservers(ctx context.Context, arg GetStatsTopObserversParams) ([]GetStatsTopObserversRow, error)
 	// Returns the top N companion names by decrypted channel message count for the given
 	// window and IATA. Grouped by sender_name as decrypted from the message itself, not by
@@ -159,6 +160,7 @@ type Querier interface {
 	RefreshPayloadBreakdown(ctx context.Context) error
 	RefreshRadioPresets(ctx context.Context) error
 	RefreshTopNodes(ctx context.Context) error
+	RefreshTopObservers(ctx context.Context) error
 	// ============================================================
 	// HELPERS
 	// ============================================================

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -19,6 +19,8 @@ type Querier interface {
 	DeleteOldPackets(ctx context.Context, lastHeardAt pgtype.Timestamptz) error
 	// Deletes telemetry rows older than the given cutoff. Called by the cleanup goroutine.
 	DeleteOldTelemetry(ctx context.Context, reportedAt pgtype.Timestamptz) error
+	// Keeps the trace IATA filter in step with packet retention.
+	DeleteOldTraceIATAs(ctx context.Context, lastHeard pgtype.Timestamptz) error
 	GetChannelByID(ctx context.Context, id int32) (Channel, error)
 	// Returns neighbors of a node that are in a different IATA.
 	GetCrossIATANeighbors(ctx context.Context, arg GetCrossIATANeighborsParams) ([]GetCrossIATANeighborsRow, error)
@@ -142,6 +144,8 @@ type Querier interface {
 	// TRACES
 	// ============================================================
 	// Returns distinct trace tags with summary info, ordered by most recent first.
+	// IATA membership comes from trace_iatas (joining observations here spilled the
+	// hash join). Per-tag details filled in only for the returned page.
 	ListTraceTags(ctx context.Context, arg ListTraceTagsParams) ([]ListTraceTagsRow, error)
 	// Delete node_neighbors where the neighbor has departed from node_short_ids
 	// for that IATA, or where its prefix_4 is now ambiguous.
@@ -232,6 +236,7 @@ type Querier interface {
 	UpsertPacket(ctx context.Context, arg UpsertPacketParams) (UpsertPacketRow, error)
 	UpsertRegion(ctx context.Context, arg UpsertRegionParams) (int32, error)
 	UpsertRegionIATA(ctx context.Context, arg UpsertRegionIATAParams) error
+	UpsertTraceIATA(ctx context.Context, arg UpsertTraceIATAParams) error
 	// ============================================================
 	// TRANSPORT CODES
 	// ============================================================

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -182,6 +182,7 @@ type Querier interface {
 	// hash-only records (key unknown). Returns the channel row.
 	UpsertChannel(ctx context.Context, arg UpsertChannelParams) (Channel, error)
 	UpsertChannelHashOnly(ctx context.Context, channelHash []byte) (int32, error)
+	// Refreshes at most hourly so repeat hears don't churn the row.
 	UpsertChannelIATA(ctx context.Context, arg UpsertChannelIATAParams) error
 	// Copyright 2026 Beacon Contributors
 	// SPDX-License-Identifier: agpl

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -12,6 +12,8 @@ import (
 )
 
 type Querier interface {
+	// Keeps the channel IATA filter in step with packet retention.
+	DeleteOldChannelIATAs(ctx context.Context, lastHeard pgtype.Timestamptz) error
 	// Deletes packets and their observations older than the given cutoff.
 	// packet_observations cascade-delete via FK.
 	DeleteOldPackets(ctx context.Context, lastHeardAt pgtype.Timestamptz) error
@@ -97,9 +99,8 @@ type Querier interface {
 	// Pass empty string for iata or scope to skip those filters.
 	// Pass cursor=0 to start from the beginning.
 	ListChannelMessagesByHash(ctx context.Context, arg ListChannelMessagesByHashParams) ([]ListChannelMessagesByHashRow, error)
-	// Returns channels ordered by last seen, optionally filtered by hash and/or IATA.
-	// Pass NULL for hash to skip hash filtering. Pass empty string for iata to skip IATA filtering.
-	// IATA filter returns channels that have active packets in that IATA (case-insensitive).
+	// Channels ordered by last seen, optionally filtered by hash and/or IATAs
+	// (membership via channel_iatas). NULL hash / empty array skip those filters.
 	// Pass cursor=0 to start from the beginning (cursor is last_seen epoch ms).
 	ListChannels(ctx context.Context, arg ListChannelsParams) ([]Channel, error)
 	ListIATAs(ctx context.Context) ([]IataCode, error)
@@ -181,6 +182,7 @@ type Querier interface {
 	// hash-only records (key unknown). Returns the channel row.
 	UpsertChannel(ctx context.Context, arg UpsertChannelParams) (Channel, error)
 	UpsertChannelHashOnly(ctx context.Context, channelHash []byte) (int32, error)
+	UpsertChannelIATA(ctx context.Context, arg UpsertChannelIATAParams) error
 	// Copyright 2026 Beacon Contributors
 	// SPDX-License-Identifier: agpl
 	// ============================================================

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -50,6 +50,8 @@ type Querier interface {
 	GetRegionIATAs(ctx context.Context, regionID int32) ([]string, error)
 	GetScopeByName(ctx context.Context, name string) (GetScopeByNameRow, error)
 	GetScopeNames(ctx context.Context) ([]string, error)
+	// Count each table on its own; the old cross-join blew up to millions of rows
+	// before COUNT(DISTINCT) (~10s).
 	GetScopeStats(ctx context.Context) ([]GetScopeStatsRow, error)
 	GetScopesByIATAs(ctx context.Context, dollar_1 []string) ([]GetScopesByIATAsRow, error)
 	// Returns node counts grouped by type, optionally filtered by IATA.

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -236,6 +236,7 @@ type Querier interface {
 	UpsertPacket(ctx context.Context, arg UpsertPacketParams) (UpsertPacketRow, error)
 	UpsertRegion(ctx context.Context, arg UpsertRegionParams) (int32, error)
 	UpsertRegionIATA(ctx context.Context, arg UpsertRegionIATAParams) error
+	// Refreshes at most hourly so repeat hears don't churn the row.
 	UpsertTraceIATA(ctx context.Context, arg UpsertTraceIATAParams) error
 	// ============================================================
 	// TRANSPORT CODES

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -43,6 +43,16 @@ func (q *Queries) DeleteOldTelemetry(ctx context.Context, reportedAt pgtype.Time
 	return err
 }
 
+const deleteOldTraceIATAs = `-- name: DeleteOldTraceIATAs :exec
+DELETE FROM trace_iatas WHERE last_heard < $1
+`
+
+// Keeps the trace IATA filter in step with packet retention.
+func (q *Queries) DeleteOldTraceIATAs(ctx context.Context, lastHeard pgtype.Timestamptz) error {
+	_, err := q.db.Exec(ctx, deleteOldTraceIATAs, lastHeard)
+	return err
+}
+
 const getChannelByID = `-- name: GetChannelByID :one
 SELECT id, channel_hash, key_fingerprint, name, hashtag, is_hashtag, is_public, key_known, first_seen, last_seen, message_count FROM channels WHERE id = $1
 `
@@ -2901,33 +2911,43 @@ func (q *Queries) ListRegions(ctx context.Context) ([]ListRegionsRow, error) {
 
 const listTraceTags = `-- name: ListTraceTags :many
 
+WITH tags AS (
+    SELECT
+        p.trace_tag,
+        MIN(p.first_heard_at) AS first_heard_at,
+        MAX(p.last_heard_at) AS last_heard_at,
+        COUNT(*) AS packet_count,
+        MAX(p.parsed_payload->>'type') AS trace_type
+    FROM packets p
+    WHERE p.trace_tag IS NOT NULL
+      AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR p.trace_tag IN (
+          SELECT ti.trace_tag FROM trace_iatas ti WHERE ti.iata = ANY($1::bpchar[])))
+      AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
+      AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
+      AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
+      AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
+      AND ($7::text = '' OR p.parsed_payload->>'type' = $7)
+    GROUP BY p.trace_tag
+    ORDER BY MAX(p.last_heard_at) DESC
+    LIMIT $6
+)
 SELECT
-    encode(p.trace_tag, 'hex') AS trace_tag,
-    MIN(p.first_heard_at)::timestamptz AS first_heard_at,
-    MAX(p.last_heard_at)::timestamptz AS last_heard_at,
-    COUNT(DISTINCT p.packet_hash) AS packet_count,
-    COUNT(DISTINCT po.iata) AS iata_count,
-    MAX(p.parsed_payload->>'type')::text AS trace_type,
-    best.parsed_payload AS best_payload
-FROM packets p
-LEFT JOIN packet_observations po ON po.packet_hash = p.packet_hash
-LEFT JOIN LATERAL (
-    SELECT parsed_payload
-    FROM packets p2
-    WHERE p2.trace_tag = p.trace_tag
-    ORDER BY jsonb_array_length(p2.parsed_payload->'pathHashes') DESC
-    LIMIT 1
-) best ON true
-WHERE p.trace_tag IS NOT NULL
-  AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR po.iata = ANY($1::bpchar[]))
-  AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
-  AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
-  AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
-  AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
-  AND ($7::text = '' OR p.parsed_payload->>'type' = $7)
-GROUP BY p.trace_tag, best.parsed_payload
-ORDER BY MAX(p.last_heard_at) DESC
-LIMIT $6
+    encode(t.trace_tag, 'hex') AS trace_tag,
+    t.first_heard_at::timestamptz AS first_heard_at,
+    t.last_heard_at::timestamptz AS last_heard_at,
+    t.packet_count,
+    (SELECT COUNT(*)
+     FROM trace_iatas ti
+     WHERE ti.trace_tag = t.trace_tag
+       AND (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR ti.iata = ANY($1::bpchar[]))) AS iata_count,
+    t.trace_type::text AS trace_type,
+    (SELECT p3.parsed_payload
+     FROM packets p3
+     WHERE p3.trace_tag = t.trace_tag
+     ORDER BY jsonb_array_length(p3.parsed_payload->'pathHashes') DESC
+     LIMIT 1) AS best_payload
+FROM tags t
+ORDER BY t.last_heard_at DESC
 `
 
 type ListTraceTagsParams struct {
@@ -2954,6 +2974,8 @@ type ListTraceTagsRow struct {
 // TRACES
 // ============================================================
 // Returns distinct trace tags with summary info, ordered by most recent first.
+// IATA membership comes from trace_iatas (joining observations here spilled the
+// hash join). Per-tag details filled in only for the returned page.
 func (q *Queries) ListTraceTags(ctx context.Context, arg ListTraceTagsParams) ([]ListTraceTagsRow, error) {
 	rows, err := q.db.Query(ctx, listTraceTags,
 		arg.Column1,
@@ -4043,6 +4065,24 @@ type UpsertRegionIATAParams struct {
 
 func (q *Queries) UpsertRegionIATA(ctx context.Context, arg UpsertRegionIATAParams) error {
 	_, err := q.db.Exec(ctx, upsertRegionIATA, arg.RegionID, arg.Iata)
+	return err
+}
+
+const upsertTraceIATA = `-- name: UpsertTraceIATA :exec
+INSERT INTO trace_iatas (trace_tag, iata, last_heard)
+VALUES ($1, $2, $3)
+ON CONFLICT (trace_tag, iata) DO UPDATE SET
+  last_heard = GREATEST(trace_iatas.last_heard, EXCLUDED.last_heard)
+`
+
+type UpsertTraceIATAParams struct {
+	TraceTag  []byte             `json:"trace_tag"`
+	Iata      string             `json:"iata"`
+	LastHeard pgtype.Timestamptz `json:"last_heard"`
+}
+
+func (q *Queries) UpsertTraceIATA(ctx context.Context, arg UpsertTraceIATAParams) error {
+	_, err := q.db.Exec(ctx, upsertTraceIATA, arg.TraceTag, arg.Iata, arg.LastHeard)
 	return err
 }
 

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -1303,41 +1303,37 @@ func (q *Queries) GetStatsTopAdvertisers(ctx context.Context, arg GetStatsTopAdv
 
 const getStatsTopObservers = `-- name: GetStatsTopObservers :many
 SELECT
-  o.id,
-  o.display_name,
-  o.observer_type,
-  COUNT(*) AS observation_count,
-  COALESCE((
-    SELECT po2.iata FROM packet_observations po2
-    WHERE po2.observer_id = o.id
-    ORDER BY po2.heard_at DESC LIMIT 1
-  ), '') AS iata
-FROM packet_observations po
-JOIN observers o ON o.id = po.observer_id
-WHERE po.heard_at > $1
-  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
-GROUP BY o.id
+  observer_id AS id,
+  display_name,
+  observer_type,
+  COALESCE(SUM(observation_count), 0)::bigint AS observation_count,
+  COALESCE(MAX(iata), '')::bpchar AS iata
+FROM mv_top_observers_by_iata
+WHERE last_heard > $1
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR iata = ANY($2::bpchar[]))
+GROUP BY observer_id, display_name, observer_type
 ORDER BY observation_count DESC
 LIMIT $3
 `
 
 type GetStatsTopObserversParams struct {
-	HeardAt pgtype.Timestamptz `json:"heard_at"`
-	Column2 []string           `json:"column_2"`
-	Limit   int32              `json:"limit"`
+	LastHeard interface{} `json:"last_heard"`
+	Column2   []string    `json:"column_2"`
+	Limit     int32       `json:"limit"`
 }
 
 type GetStatsTopObserversRow struct {
-	ID               uuid.UUID   `json:"id"`
-	DisplayName      *string     `json:"display_name"`
-	ObserverType     *string     `json:"observer_type"`
-	ObservationCount int64       `json:"observation_count"`
-	Iata             interface{} `json:"iata"`
+	ID               uuid.UUID `json:"id"`
+	DisplayName      *string   `json:"display_name"`
+	ObserverType     *string   `json:"observer_type"`
+	ObservationCount int64     `json:"observation_count"`
+	Iata             string    `json:"iata"`
 }
 
-// Returns the top N observers by observation count for the given window and IATA.
+// Top N observers for the IATA, from the precomputed view. Counts sum across
+// matched IATAs; iata is a representative one for display.
 func (q *Queries) GetStatsTopObservers(ctx context.Context, arg GetStatsTopObserversParams) ([]GetStatsTopObserversRow, error) {
-	rows, err := q.db.Query(ctx, getStatsTopObservers, arg.HeardAt, arg.Column2, arg.Limit)
+	rows, err := q.db.Query(ctx, getStatsTopObservers, arg.LastHeard, arg.Column2, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -3096,6 +3092,15 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_nodes_by_iata
 
 func (q *Queries) RefreshTopNodes(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, refreshTopNodes)
+	return err
+}
+
+const refreshTopObservers = `-- name: RefreshTopObservers :exec
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_observers_by_iata
+`
+
+func (q *Queries) RefreshTopObservers(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, refreshTopObservers)
 	return err
 }
 

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -3567,7 +3567,8 @@ const upsertChannelIATA = `-- name: UpsertChannelIATA :exec
 INSERT INTO channel_iatas (channel_hash, iata, last_heard)
 VALUES ($1, $2, $3)
 ON CONFLICT (channel_hash, iata) DO UPDATE SET
-  last_heard = GREATEST(channel_iatas.last_heard, EXCLUDED.last_heard)
+  last_heard = EXCLUDED.last_heard
+WHERE EXCLUDED.last_heard > channel_iatas.last_heard + INTERVAL '1 hour'
 `
 
 type UpsertChannelIATAParams struct {
@@ -3576,6 +3577,7 @@ type UpsertChannelIATAParams struct {
 	LastHeard   pgtype.Timestamptz `json:"last_heard"`
 }
 
+// Refreshes at most hourly so repeat hears don't churn the row.
 func (q *Queries) UpsertChannelIATA(ctx context.Context, arg UpsertChannelIATAParams) error {
 	_, err := q.db.Exec(ctx, upsertChannelIATA, arg.ChannelHash, arg.Iata, arg.LastHeard)
 	return err

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -1197,29 +1197,22 @@ func (q *Queries) GetStatsOverview(ctx context.Context, dollar_1 []string) (GetS
 
 const getStatsPayloadBreakdown = `-- name: GetStatsPayloadBreakdown :many
 SELECT
-  p.payload_type,
-  COUNT(*) AS count
-FROM packet_observations po
-JOIN packets p ON p.packet_hash = po.packet_hash
-WHERE po.heard_at > $1
-  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR po.iata = ANY($2::bpchar[]))
-GROUP BY p.payload_type
+  payload_type,
+  SUM(count)::bigint AS count
+FROM mv_payload_breakdown_by_iata
+WHERE (COALESCE(cardinality($1::bpchar[]), 0) = 0 OR iata = ANY($1::bpchar[]))
+GROUP BY payload_type
 ORDER BY count DESC
 `
 
-type GetStatsPayloadBreakdownParams struct {
-	HeardAt pgtype.Timestamptz `json:"heard_at"`
-	Column2 []string           `json:"column_2"`
-}
-
 type GetStatsPayloadBreakdownRow struct {
-	PayloadType int16 `json:"payload_type"`
-	Count       int64 `json:"count"`
+	PayloadType *int16 `json:"payload_type"`
+	Count       int64  `json:"count"`
 }
 
-// Returns observation counts grouped by payload type for the given window and IATA.
-func (q *Queries) GetStatsPayloadBreakdown(ctx context.Context, arg GetStatsPayloadBreakdownParams) ([]GetStatsPayloadBreakdownRow, error) {
-	rows, err := q.db.Query(ctx, getStatsPayloadBreakdown, arg.HeardAt, arg.Column2)
+// Payload-type counts for the IATA, from the precomputed view.
+func (q *Queries) GetStatsPayloadBreakdown(ctx context.Context, dollar_1 []string) ([]GetStatsPayloadBreakdownRow, error) {
+	rows, err := q.db.Query(ctx, getStatsPayloadBreakdown, dollar_1)
 	if err != nil {
 		return nil, err
 	}
@@ -1551,12 +1544,13 @@ INSERT INTO packet_observations (
   spread_factor,
   bandwidth_khz,
   coding_rate,
-  source_broker
+  source_broker,
+  payload_type
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
 )
 ON CONFLICT (packet_hash, observer_id) DO NOTHING
-RETURNING id, packet_hash, observer_id, iata, heard_at, path_length_byte, hash_size, hop_count, path_bytes, rssi, snr, propagation_time_ms, radio_freq_mhz, spread_factor, bandwidth_khz, coding_rate, source_broker
+RETURNING id, packet_hash, observer_id, iata, heard_at, path_length_byte, hash_size, hop_count, path_bytes, rssi, snr, propagation_time_ms, radio_freq_mhz, spread_factor, bandwidth_khz, coding_rate, source_broker, payload_type
 `
 
 type InsertObservationParams struct {
@@ -1576,6 +1570,7 @@ type InsertObservationParams struct {
 	BandwidthKhz      *float32           `json:"bandwidth_khz"`
 	CodingRate        *int16             `json:"coding_rate"`
 	SourceBroker      *string            `json:"source_broker"`
+	PayloadType       *int16             `json:"payload_type"`
 }
 
 // ============================================================
@@ -1599,6 +1594,7 @@ func (q *Queries) InsertObservation(ctx context.Context, arg InsertObservationPa
 		arg.BandwidthKhz,
 		arg.CodingRate,
 		arg.SourceBroker,
+		arg.PayloadType,
 	)
 	var i PacketObservation
 	err := row.Scan(
@@ -1619,6 +1615,7 @@ func (q *Queries) InsertObservation(ctx context.Context, arg InsertObservationPa
 		&i.BandwidthKhz,
 		&i.CodingRate,
 		&i.SourceBroker,
+		&i.PayloadType,
 	)
 	return i, err
 }
@@ -2293,7 +2290,7 @@ func (q *Queries) ListNodes(ctx context.Context, arg ListNodesParams) ([]ListNod
 }
 
 const listObservationsForPacket = `-- name: ListObservationsForPacket :many
-SELECT po.id, po.packet_hash, po.observer_id, po.iata, po.heard_at, po.path_length_byte, po.hash_size, po.hop_count, po.path_bytes, po.rssi, po.snr, po.propagation_time_ms, po.radio_freq_mhz, po.spread_factor, po.bandwidth_khz, po.coding_rate, po.source_broker, o.display_name AS observer_name
+SELECT po.id, po.packet_hash, po.observer_id, po.iata, po.heard_at, po.path_length_byte, po.hash_size, po.hop_count, po.path_bytes, po.rssi, po.snr, po.propagation_time_ms, po.radio_freq_mhz, po.spread_factor, po.bandwidth_khz, po.coding_rate, po.source_broker, po.payload_type, o.display_name AS observer_name
 FROM packet_observations po
 LEFT JOIN observers o ON o.id = po.observer_id
 WHERE po.packet_hash = $1
@@ -2318,6 +2315,7 @@ type ListObservationsForPacketRow struct {
 	BandwidthKhz      *float32           `json:"bandwidth_khz"`
 	CodingRate        *int16             `json:"coding_rate"`
 	SourceBroker      *string            `json:"source_broker"`
+	PayloadType       *int16             `json:"payload_type"`
 	ObserverName      *string            `json:"observer_name"`
 }
 
@@ -2348,6 +2346,7 @@ func (q *Queries) ListObservationsForPacket(ctx context.Context, packetHash []by
 			&i.BandwidthKhz,
 			&i.CodingRate,
 			&i.SourceBroker,
+			&i.PayloadType,
 			&i.ObserverName,
 		); err != nil {
 			return nil, err
@@ -3070,6 +3069,15 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY mv_hourly_iata_stats
 
 func (q *Queries) RefreshHourlyStats(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, refreshHourlyStats)
+	return err
+}
+
+const refreshPayloadBreakdown = `-- name: RefreshPayloadBreakdown :exec
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_payload_breakdown_by_iata
+`
+
+func (q *Queries) RefreshPayloadBreakdown(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, refreshPayloadBreakdown)
 	return err
 }
 

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -12,6 +12,16 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteOldChannelIATAs = `-- name: DeleteOldChannelIATAs :exec
+DELETE FROM channel_iatas WHERE last_heard < $1
+`
+
+// Keeps the channel IATA filter in step with packet retention.
+func (q *Queries) DeleteOldChannelIATAs(ctx context.Context, lastHeard pgtype.Timestamptz) error {
+	_, err := q.db.Exec(ctx, deleteOldChannelIATAs, lastHeard)
+	return err
+}
+
 const deleteOldPackets = `-- name: DeleteOldPackets :exec
 DELETE FROM packets WHERE last_heard_at < $1
 `
@@ -1883,13 +1893,11 @@ func (q *Queries) ListChannelMessagesByHash(ctx context.Context, arg ListChannel
 }
 
 const listChannels = `-- name: ListChannels :many
-SELECT DISTINCT c.id, c.channel_hash, c.key_fingerprint, c.name, c.hashtag, c.is_hashtag, c.is_public, c.key_known, c.first_seen, c.last_seen, c.message_count FROM channels c
+SELECT c.id, c.channel_hash, c.key_fingerprint, c.name, c.hashtag, c.is_hashtag, c.is_public, c.key_known, c.first_seen, c.last_seen, c.message_count FROM channels c
 WHERE ($1::bytea IS NULL OR c.channel_hash = $1)
-  AND ($2 = '' OR EXISTS (
-    SELECT 1 FROM packets p
-    JOIN packet_observations po ON po.packet_hash = p.packet_hash
-    WHERE p.channel_hash = c.channel_hash
-      AND po.iata ILIKE $2
+  AND (COALESCE(cardinality($2::bpchar[]), 0) = 0 OR c.channel_hash IN (
+    SELECT ci.channel_hash FROM channel_iatas ci
+    WHERE ci.iata = ANY($2::bpchar[])
   ))
   AND ($3::timestamptz IS NULL OR c.last_seen < $3)
 ORDER BY c.last_seen DESC
@@ -1897,22 +1905,21 @@ LIMIT $4
 `
 
 type ListChannelsParams struct {
-	Column1 []byte             `json:"column_1"`
-	Column2 interface{}        `json:"column_2"`
-	Column3 pgtype.Timestamptz `json:"column_3"`
-	Limit   int32              `json:"limit"`
+	ChannelHash []byte             `json:"channel_hash"`
+	Iatas       []string           `json:"iatas"`
+	CursorTs    pgtype.Timestamptz `json:"cursor_ts"`
+	PageLimit   int32              `json:"page_limit"`
 }
 
-// Returns channels ordered by last seen, optionally filtered by hash and/or IATA.
-// Pass NULL for hash to skip hash filtering. Pass empty string for iata to skip IATA filtering.
-// IATA filter returns channels that have active packets in that IATA (case-insensitive).
+// Channels ordered by last seen, optionally filtered by hash and/or IATAs
+// (membership via channel_iatas). NULL hash / empty array skip those filters.
 // Pass cursor=0 to start from the beginning (cursor is last_seen epoch ms).
 func (q *Queries) ListChannels(ctx context.Context, arg ListChannelsParams) ([]Channel, error) {
 	rows, err := q.db.Query(ctx, listChannels,
-		arg.Column1,
-		arg.Column2,
-		arg.Column3,
-		arg.Limit,
+		arg.ChannelHash,
+		arg.Iatas,
+		arg.CursorTs,
+		arg.PageLimit,
 	)
 	if err != nil {
 		return nil, err
@@ -3554,6 +3561,24 @@ func (q *Queries) UpsertChannelHashOnly(ctx context.Context, channelHash []byte)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
+}
+
+const upsertChannelIATA = `-- name: UpsertChannelIATA :exec
+INSERT INTO channel_iatas (channel_hash, iata, last_heard)
+VALUES ($1, $2, $3)
+ON CONFLICT (channel_hash, iata) DO UPDATE SET
+  last_heard = GREATEST(channel_iatas.last_heard, EXCLUDED.last_heard)
+`
+
+type UpsertChannelIATAParams struct {
+	ChannelHash []byte             `json:"channel_hash"`
+	Iata        string             `json:"iata"`
+	LastHeard   pgtype.Timestamptz `json:"last_heard"`
+}
+
+func (q *Queries) UpsertChannelIATA(ctx context.Context, arg UpsertChannelIATAParams) error {
+	_, err := q.db.Exec(ctx, upsertChannelIATA, arg.ChannelHash, arg.Iata, arg.LastHeard)
+	return err
 }
 
 const upsertIATA = `-- name: UpsertIATA :exec

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -4072,7 +4072,8 @@ const upsertTraceIATA = `-- name: UpsertTraceIATA :exec
 INSERT INTO trace_iatas (trace_tag, iata, last_heard)
 VALUES ($1, $2, $3)
 ON CONFLICT (trace_tag, iata) DO UPDATE SET
-  last_heard = GREATEST(trace_iatas.last_heard, EXCLUDED.last_heard)
+  last_heard = EXCLUDED.last_heard
+WHERE EXCLUDED.last_heard > trace_iatas.last_heard + INTERVAL '1 hour'
 `
 
 type UpsertTraceIATAParams struct {
@@ -4081,6 +4082,7 @@ type UpsertTraceIATAParams struct {
 	LastHeard pgtype.Timestamptz `json:"last_heard"`
 }
 
+// Refreshes at most hourly so repeat hears don't churn the row.
 func (q *Queries) UpsertTraceIATA(ctx context.Context, arg UpsertTraceIATAParams) error {
 	_, err := q.db.Exec(ctx, upsertTraceIATA, arg.TraceTag, arg.Iata, arg.LastHeard)
 	return err

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -1035,14 +1035,10 @@ func (q *Queries) GetScopeNames(ctx context.Context) ([]string, error) {
 const getScopeStats = `-- name: GetScopeStats :many
 SELECT
     ts.name,
-    COUNT(DISTINCT p.packet_hash) AS packet_count,
-    COUNT(DISTINCT os.observer_id) AS observer_count,
-    COUNT(DISTINCT n.id) AS node_count
+    (SELECT COUNT(*) FROM packets p WHERE p.scope_id = ts.id) AS packet_count,
+    (SELECT COUNT(*) FROM observer_scopes os WHERE os.scope_id = ts.id) AS observer_count,
+    (SELECT COUNT(*) FROM nodes n WHERE n.default_scope_id = ts.id) AS node_count
 FROM transport_scopes ts
-LEFT JOIN packets p ON p.scope_id = ts.id
-LEFT JOIN observer_scopes os ON os.scope_id = ts.id
-LEFT JOIN nodes n ON n.default_scope_id = ts.id
-GROUP BY ts.name
 ORDER BY ts.name
 `
 
@@ -1053,6 +1049,8 @@ type GetScopeStatsRow struct {
 	NodeCount     int64  `json:"node_count"`
 }
 
+// Count each table on its own; the old cross-join blew up to millions of rows
+// before COUNT(DISTINCT) (~10s).
 func (q *Queries) GetScopeStats(ctx context.Context) ([]GetScopeStatsRow, error) {
 	rows, err := q.db.Query(ctx, getScopeStats)
 	if err != nil {

--- a/db/stats.go
+++ b/db/stats.go
@@ -51,22 +51,20 @@ func (s *Store) GetStatsObservations(ctx context.Context, iatas []string, since 
 	return points, nil
 }
 
-func (s *Store) GetStatsPayloadBreakdown(ctx context.Context, iatas []string, since time.Time) ([]api.PayloadBreakdownItem, error) {
-	if since.IsZero() {
-		since = time.Now().Add(-24 * time.Hour)
-	}
-	rows, err := s.q.GetStatsPayloadBreakdown(ctx, sqlc.GetStatsPayloadBreakdownParams{
-		HeardAt: pgtype.Timestamptz{Time: since, Valid: true},
-		Column2: iatas,
-	})
+// since is unused: the view is a rolling 7-day window refreshed on a timer.
+func (s *Store) GetStatsPayloadBreakdown(ctx context.Context, iatas []string, _ time.Time) ([]api.PayloadBreakdownItem, error) {
+	rows, err := s.q.GetStatsPayloadBreakdown(ctx, iatas)
 	if err != nil {
 		return nil, err
 	}
 	items := make([]api.PayloadBreakdownItem, 0, len(rows))
 	for _, v := range rows {
+		if v.PayloadType == nil {
+			continue
+		}
 		items = append(items, api.PayloadBreakdownItem{
-			PayloadType:     v.PayloadType,
-			PayloadTypeName: api.PayloadTypeName(v.PayloadType),
+			PayloadType:     *v.PayloadType,
+			PayloadTypeName: api.PayloadTypeName(*v.PayloadType),
 			Count:           v.Count,
 		})
 	}
@@ -242,6 +240,10 @@ func (s *Store) RefreshHourlyStats(ctx context.Context) error {
 
 func (s *Store) RefreshTopNodes(ctx context.Context) error {
 	return s.q.RefreshTopNodes(ctx)
+}
+
+func (s *Store) RefreshPayloadBreakdown(ctx context.Context) error {
+	return s.q.RefreshPayloadBreakdown(ctx)
 }
 
 func (s *Store) RefreshRadioPresets(ctx context.Context) error {

--- a/db/stats.go
+++ b/db/stats.go
@@ -103,21 +103,20 @@ func (s *Store) GetStatsTopObservers(ctx context.Context, iatas []string, since 
 		since = time.Now().Add(-24 * time.Hour)
 	}
 	rows, err := s.q.GetStatsTopObservers(ctx, sqlc.GetStatsTopObserversParams{
-		HeardAt: pgtype.Timestamptz{Time: since, Valid: true},
-		Column2: iatas,
-		Limit:   limit,
+		LastHeard: pgtype.Timestamptz{Time: since, Valid: true},
+		Column2:   iatas,
+		Limit:     limit,
 	})
 	if err != nil {
 		return nil, err
 	}
 	items := make([]api.TopObserver, 0, len(rows))
 	for _, v := range rows {
-		iata, _ := v.Iata.(string)
 		items = append(items, api.TopObserver{
 			ObserverID:       v.ID,
 			DisplayName:      v.DisplayName,
 			ObserverType:     v.ObserverType,
-			IATA:             iata,
+			IATA:             v.Iata,
 			ObservationCount: v.ObservationCount,
 		})
 	}
@@ -244,6 +243,10 @@ func (s *Store) RefreshTopNodes(ctx context.Context) error {
 
 func (s *Store) RefreshPayloadBreakdown(ctx context.Context) error {
 	return s.q.RefreshPayloadBreakdown(ctx)
+}
+
+func (s *Store) RefreshTopObservers(ctx context.Context) error {
+	return s.q.RefreshTopObservers(ctx)
 }
 
 func (s *Store) RefreshRadioPresets(ctx context.Context) error {

--- a/db/traces.go
+++ b/db/traces.go
@@ -20,6 +20,18 @@ type tracePayload struct {
 	SNRValues  []float32 `json:"snrValues"`
 }
 
+func (s *Store) UpsertTraceIATA(ctx context.Context, traceTag []byte, iata string, heardAt time.Time) error {
+	return s.q.UpsertTraceIATA(ctx, sqlc.UpsertTraceIATAParams{
+		TraceTag:  traceTag,
+		Iata:      iata,
+		LastHeard: pgtype.Timestamptz{Time: heardAt, Valid: true},
+	})
+}
+
+func (s *Store) DeleteOldTraceIATAs(ctx context.Context, cutoff time.Time) error {
+	return s.q.DeleteOldTraceIATAs(ctx, pgtype.Timestamptz{Time: cutoff, Valid: true})
+}
+
 func (s *Store) ListTraceTags(ctx context.Context, iatas []string, scope, traceType string, since, until time.Time, cursor time.Time, limit int32) ([]api.TraceTagSummary, error) {
 	var sinceTS, untilTS, cursorTS pgtype.Timestamptz
 	if !since.IsZero() {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4,11 +4,11 @@ package docs
 import "github.com/swaggo/swag"
 
 const docTemplate = `{
-    "schemes": [[ marshal .Schemes ]],
+    "schemes": {{ marshal .Schemes }},
     "swagger": "2.0",
     "info": {
-        "description": "[[escape .Description]]",
-        "title": "[[.Title]]",
+        "description": "{{escape .Description}}",
+        "title": "{{.Title}}",
         "termsOfService": "https://github.com/MeshCore-Beacon/beacon-server",
         "contact": {
             "name": "MeshCore Beacon",
@@ -17,10 +17,10 @@ const docTemplate = `{
         "license": {
             "name": "AGPL-3-or-later"
         },
-        "version": "[[.Version]]"
+        "version": "{{.Version}}"
     },
-    "host": "[[.Host]]",
-    "basePath": "[[.BasePath]]",
+    "host": "{{.Host}}",
+    "basePath": "{{.BasePath}}",
     "paths": {
         "/brokers": {
             "get": {
@@ -64,6 +64,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by IATA code (case-insensitive)",
                         "name": "iata",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by IATA code(s), comma-separated e.g. YOW or YOW,YYZ",
+                        "name": "iatas",
                         "in": "query"
                     },
                     {
@@ -3768,8 +3774,8 @@ var SwaggerInfo = &swag.Spec{
 	Description:      "MeshCore network observation backend. Ingests LoRa packets from MQTT brokers, stores in PostgreSQL, and streams live events via WebSocket.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
-	LeftDelim:        "[[",
-	RightDelim:       "]]",
+	LeftDelim:        "{{",
+	RightDelim:       "}}",
 }
 
 func init() {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -62,7 +62,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter by IATA code (case-insensitive)",
+                        "description": "Filter by IATA code",
                         "name": "iata",
                         "in": "query"
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -65,6 +65,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by IATA code(s), comma-separated e.g. YOW or YOW,YYZ",
+                        "name": "iatas",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "last_seen epoch ms of last item for pagination",
                         "name": "cursor",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -60,7 +60,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filter by IATA code (case-insensitive)",
+                        "description": "Filter by IATA code",
                         "name": "iata",
                         "in": "query"
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1098,7 +1098,7 @@ paths:
         in: query
         name: hash
         type: string
-      - description: Filter by IATA code (case-insensitive)
+      - description: Filter by IATA code
         in: query
         name: iata
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1102,6 +1102,10 @@ paths:
         in: query
         name: iata
         type: string
+      - description: Filter by IATA code(s), comma-separated e.g. YOW or YOW,YYZ
+        in: query
+        name: iatas
+        type: string
       - description: last_seen epoch ms of last item for pagination
         in: query
         name: cursor

--- a/internal/api/handlers/channels.go
+++ b/internal/api/handlers/channels.go
@@ -36,6 +36,7 @@ func ChannelsRouter(reader api.Reader) http.Handler {
 //	@Produce	json
 //	@Param		hash	query		string	false	"Single-byte channel hash (hex)"
 //	@Param		iata	query		string	false	"Filter by IATA code (case-insensitive)"
+//	@Param		iatas	query		string	false	"Filter by IATA code(s), comma-separated e.g. YOW or YOW,YYZ"
 //	@Param		cursor	query		int		false	"last_seen epoch ms of last item for pagination"
 //	@Param		limit	query		int		false	"Max results (default 50)"
 //	@Success	200		{object}	api.Page[api.ChannelSummary]
@@ -53,7 +54,7 @@ func listChannels(reader api.Reader) http.HandlerFunc {
 			}
 			limit = l
 		}
-		iata := r.URL.Query().Get("iata")
+		iatas := parseIATAs(r)
 		var cursor int64
 		if cursorParam := r.URL.Query().Get("cursor"); cursorParam != "" {
 			c, err := strconv.ParseInt(cursorParam, 10, 64)
@@ -76,7 +77,7 @@ func listChannels(reader api.Reader) http.HandlerFunc {
 			}
 			hashHex = h
 		}
-		channels, err := reader.ListChannels(r.Context(), int32(limit), hashHex, iata, cursor)
+		channels, err := reader.ListChannels(r.Context(), int32(limit), hashHex, iatas, cursor)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "internal server error")
 			return

--- a/internal/api/handlers/channels.go
+++ b/internal/api/handlers/channels.go
@@ -35,7 +35,7 @@ func ChannelsRouter(reader api.Reader) http.Handler {
 //	@Tags		Channels
 //	@Produce	json
 //	@Param		hash	query		string	false	"Single-byte channel hash (hex)"
-//	@Param		iata	query		string	false	"Filter by IATA code (case-insensitive)"
+//	@Param		iata	query		string	false	"Filter by IATA code"
 //	@Param		iatas	query		string	false	"Filter by IATA code(s), comma-separated e.g. YOW or YOW,YYZ"
 //	@Param		cursor	query		int		false	"last_seen epoch ms of last item for pagination"
 //	@Param		limit	query		int		false	"Max results (default 50)"

--- a/internal/api/handlers/channels_test.go
+++ b/internal/api/handlers/channels_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/MeshCore-Beacon/beacon-server/internal/api"
@@ -115,7 +116,7 @@ func TestListChannelMessages_InvalidCursor(t *testing.T) {
 func TestListChannels_OK(t *testing.T) {
 	r := chi.NewRouter()
 	r.Get("/channels", listChannels(stubReader{
-		listChannels: func(_ context.Context, _ int32, _ []byte, _ string, _ int64) (api.Page[api.ChannelSummary], error) {
+		listChannels: func(_ context.Context, _ int32, _ []byte, _ []string, _ int64) (api.Page[api.ChannelSummary], error) {
 			return api.Page[api.ChannelSummary]{Items: []api.ChannelSummary{{ID: 1, ChannelHash: "ab"}}}, nil
 		},
 	}))
@@ -124,6 +125,39 @@ func TestListChannels_OK(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestListChannels_IATAParsing(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"single lowercased", "?iata=yow", []string{"YOW"}},
+		{"multi csv", "?iatas=yow,%20yyz", []string{"YOW", "YYZ"}},
+		{"none", "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			r := chi.NewRouter()
+			r.Get("/channels", listChannels(stubReader{
+				listChannels: func(_ context.Context, _ int32, _ []byte, iatas []string, _ int64) (api.Page[api.ChannelSummary], error) {
+					got = iatas
+					return api.Page[api.ChannelSummary]{}, nil
+				},
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/channels"+tc.query, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("expected iatas %v, got %v", tc.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/api/handlers/stub_reader_test.go
+++ b/internal/api/handlers/stub_reader_test.go
@@ -20,7 +20,7 @@ type stubReader struct {
 	listRegions                  func(ctx context.Context) ([]api.RegionSummary, error)
 	getRegion                    func(ctx context.Context, regionID int32) (*api.Region, error)
 	getRegionBySlug              func(ctx context.Context, slug string) (*api.Region, error)
-	listChannels                 func(ctx context.Context, limit int32, hash []byte, iata string, cursor int64) (api.Page[api.ChannelSummary], error)
+	listChannels                 func(ctx context.Context, limit int32, hash []byte, iatas []string, cursor int64) (api.Page[api.ChannelSummary], error)
 	getChannel                   func(ctx context.Context, channelID int32) (*api.Channel, error)
 	listChannelMessages          func(ctx context.Context, channelID *int32, since time.Time, limit int32, iatas []string, scope string, cursor int64) (api.Page[api.ChannelMessage], error)
 	listChannelMessagesByHash    func(ctx context.Context, hash []byte, since time.Time, limit int32, iatas []string, scope string, cursor int64) (api.Page[api.ChannelMessage], error)
@@ -96,9 +96,9 @@ func (s stubReader) GetRegionBySlug(ctx context.Context, slug string) (*api.Regi
 	return nil, nil
 }
 
-func (s stubReader) ListChannels(ctx context.Context, limit int32, hash []byte, iata string, cursor int64) (api.Page[api.ChannelSummary], error) {
+func (s stubReader) ListChannels(ctx context.Context, limit int32, hash []byte, iatas []string, cursor int64) (api.Page[api.ChannelSummary], error) {
 	if s.listChannels != nil {
-		return s.listChannels(ctx, limit, hash, iata, cursor)
+		return s.listChannels(ctx, limit, hash, iatas, cursor)
 	}
 	return api.Page[api.ChannelSummary]{}, nil
 }

--- a/internal/api/reader.go
+++ b/internal/api/reader.go
@@ -44,9 +44,10 @@ type Reader interface {
 
 	// ListChannels returns a paginated list of channels ordered by last seen.
 	// Includes both hashtag-derived and explicit key channels.
-	// Pass nil hash to skip hash filtering. Pass empty string iata to return all channels.
+	// Pass nil hash to skip hash filtering. Pass empty iatas to return all channels;
+	// IATAs must be uppercase.
 	// cursor is last_seen epoch ms of the last item; pass 0 to start from the beginning.
-	ListChannels(ctx context.Context, limit int32, hash []byte, iata string, cursor int64) (Page[ChannelSummary], error)
+	ListChannels(ctx context.Context, limit int32, hash []byte, iatas []string, cursor int64) (Page[ChannelSummary], error)
 
 	// GetChannel returns full detail for a single channel by its integer ID.
 	// Returns nil, pgx.ErrNoRows if the channel is not found.

--- a/internal/background/tasks.go
+++ b/internal/background/tasks.go
@@ -47,6 +47,9 @@ func CleanupTask(store *db.Store, telemetryRetention, packetRetention, interval 
 			if err := store.DeleteOldChannelIATAs(ctx, time.Now().Add(-packetRetention)); err != nil {
 				return err
 			}
+			if err := store.DeleteOldTraceIATAs(ctx, time.Now().Add(-packetRetention)); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/internal/background/tasks.go
+++ b/internal/background/tasks.go
@@ -41,13 +41,16 @@ func CleanupTask(store *db.Store, telemetryRetention, packetRetention, interval 
 			if err := store.DeleteOldTelemetry(ctx, time.Now().Add(-telemetryRetention)); err != nil {
 				return err
 			}
-			if err := store.DeleteOldPackets(ctx, time.Now().Add(-packetRetention)); err != nil {
+			// One cutoff for all three so the IATA tables stay in step
+			// with the packets they mirror.
+			cutoff := time.Now().Add(-packetRetention)
+			if err := store.DeleteOldPackets(ctx, cutoff); err != nil {
 				return err
 			}
-			if err := store.DeleteOldChannelIATAs(ctx, time.Now().Add(-packetRetention)); err != nil {
+			if err := store.DeleteOldChannelIATAs(ctx, cutoff); err != nil {
 				return err
 			}
-			if err := store.DeleteOldTraceIATAs(ctx, time.Now().Add(-packetRetention)); err != nil {
+			if err := store.DeleteOldTraceIATAs(ctx, cutoff); err != nil {
 				return err
 			}
 			return nil

--- a/internal/background/tasks.go
+++ b/internal/background/tasks.go
@@ -24,6 +24,9 @@ func ViewRefreshTask(store *db.Store, interval time.Duration) Task {
 			if err := store.RefreshTopNodes(ctx); err != nil {
 				log.Printf("background[view_refresh]: top nodes: %v", err)
 			}
+			if err := store.RefreshPayloadBreakdown(ctx); err != nil {
+				log.Printf("background[view_refresh]: payload breakdown: %v", err)
+			}
 			if err := store.RefreshRadioPresets(ctx); err != nil {
 				log.Printf("background[view_refresh]: radio presets: %v", err)
 			}

--- a/internal/background/tasks.go
+++ b/internal/background/tasks.go
@@ -24,6 +24,9 @@ func ViewRefreshTask(store *db.Store, interval time.Duration) Task {
 			if err := store.RefreshTopNodes(ctx); err != nil {
 				log.Printf("background[view_refresh]: top nodes: %v", err)
 			}
+			if err := store.RefreshTopObservers(ctx); err != nil {
+				log.Printf("background[view_refresh]: top observers: %v", err)
+			}
 			if err := store.RefreshPayloadBreakdown(ctx); err != nil {
 				log.Printf("background[view_refresh]: payload breakdown: %v", err)
 			}

--- a/internal/background/tasks.go
+++ b/internal/background/tasks.go
@@ -44,6 +44,9 @@ func CleanupTask(store *db.Store, telemetryRetention, packetRetention, interval 
 			if err := store.DeleteOldPackets(ctx, time.Now().Add(-packetRetention)); err != nil {
 				return err
 			}
+			if err := store.DeleteOldChannelIATAs(ctx, time.Now().Add(-packetRetention)); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -128,7 +128,7 @@ func (s *stubReader) GetCrossIATANeighbors(_ context.Context, _ uuid.UUID, _ str
 	return nil, nil
 }
 
-func (s *stubReader) ListChannels(_ context.Context, _ int32, _ []byte, _ string, _ int64) (api.Page[api.ChannelSummary], error) {
+func (s *stubReader) ListChannels(_ context.Context, _ int32, _ []byte, _ []string, _ int64) (api.Page[api.ChannelSummary], error) {
 	return api.Page[api.ChannelSummary]{}, nil
 }
 

--- a/internal/cache/reader.go
+++ b/internal/cache/reader.go
@@ -354,8 +354,8 @@ func (cr *CachedReader) GetCrossIATANeighbors(ctx context.Context, nodeID uuid.U
 }
 
 // ListChannels implements [api.Reader].
-func (cr *CachedReader) ListChannels(ctx context.Context, limit int32, hash []byte, iata string, cursor int64) (api.Page[api.ChannelSummary], error) {
-	return cr.inner.ListChannels(ctx, limit, hash, iata, cursor)
+func (cr *CachedReader) ListChannels(ctx context.Context, limit int32, hash []byte, iatas []string, cursor int64) (api.Page[api.ChannelSummary], error) {
+	return cr.inner.ListChannels(ctx, limit, hash, iatas, cursor)
 }
 
 // ListChannelMessages implements [api.Reader].

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -154,6 +154,9 @@ type DB interface {
 	// UpsertChannelIATA upserts a channel_iatas row.
 	UpsertChannelIATA(ctx context.Context, channelHash []byte, iata string, heardAt time.Time) error
 
+	// UpsertTraceIATA upserts a trace_iatas row.
+	UpsertTraceIATA(ctx context.Context, traceTag []byte, iata string, heardAt time.Time) error
+
 	// GetPacketObservationCount returns the number of rows for the packet observations
 	GetPacketObservationCount(ctx context.Context, packetHash []byte) (int64, error)
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -151,6 +151,9 @@ type DB interface {
 	// but can be safely ignored since unknown-key channels have no messages.
 	UpsertChannelHashOnly(ctx context.Context, channelHash []byte) (int, error)
 
+	// UpsertChannelIATA upserts a channel_iatas row.
+	UpsertChannelIATA(ctx context.Context, channelHash []byte, iata string, heardAt time.Time) error
+
 	// GetPacketObservationCount returns the number of rows for the packet observations
 	GetPacketObservationCount(ctx context.Context, packetHash []byte) (int64, error)
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -178,6 +178,7 @@ type stubDB struct {
 	upsertChannelCalls         int
 	upsertChannelHashOnlyCalls int
 	upsertChannelIATACalls     int
+	upsertTraceIATACalls       int
 	observationInserted        bool
 }
 
@@ -261,6 +262,11 @@ func (s *stubDB) UpsertChannelHashOnly(_ context.Context, _ []byte) (int, error)
 
 func (s *stubDB) UpsertChannelIATA(_ context.Context, _ []byte, _ string, _ time.Time) error {
 	s.upsertChannelIATACalls++
+	return nil
+}
+
+func (s *stubDB) UpsertTraceIATA(_ context.Context, _ []byte, _ string, _ time.Time) error {
+	s.upsertTraceIATACalls++
 	return nil
 }
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -177,6 +177,8 @@ type stubDB struct {
 	upsertNodeCalls            int
 	upsertChannelCalls         int
 	upsertChannelHashOnlyCalls int
+	upsertChannelIATACalls     int
+	observationInserted        bool
 }
 
 type setCapabilityCall struct {
@@ -201,7 +203,7 @@ func (s *stubDB) UpsertPacket(_ context.Context, _ UpsertPacketParams) (bool, er
 }
 func (s *stubDB) SetPacketDecrypted(_ context.Context, _ []byte) error { return nil }
 func (s *stubDB) InsertObservation(_ context.Context, _ InsertObservationParams) (bool, error) {
-	return false, nil
+	return s.observationInserted, nil
 }
 func (s *stubDB) SetNodeDefaultScope(_ context.Context, _ uuid.UUID, _ int32) error { return nil }
 func (s *stubDB) UpsertNode(_ context.Context, _ UpsertNodeParams, _ RadioSettings) (uuid.UUID, error) {
@@ -255,6 +257,11 @@ func (s *stubDB) UpsertChannel(_ context.Context, _ []byte, _ []byte, _, _ strin
 func (s *stubDB) UpsertChannelHashOnly(_ context.Context, _ []byte) (int, error) {
 	s.upsertChannelHashOnlyCalls++
 	return 0, nil
+}
+
+func (s *stubDB) UpsertChannelIATA(_ context.Context, _ []byte, _ string, _ time.Time) error {
+	s.upsertChannelIATACalls++
+	return nil
 }
 
 func (s *stubDB) GetPacketObservationCount(_ context.Context, _ []byte) (int64, error) {

--- a/internal/ingest/packet.go
+++ b/internal/ingest/packet.go
@@ -790,7 +790,8 @@ func (w *Worker) handlePacket(ctx context.Context, iata, pubkeyHex string, raw [
 		}
 	}
 
-	if traceTag != nil && inserted {
+	// Runs on duplicate observations too; the upsert only writes when the row is >1h stale.
+	if traceTag != nil {
 		if err := w.db.UpsertTraceIATA(ctx, traceTag, iata, heardAt); err != nil {
 			log.Printf("ingest[%s]: db: upsert trace IATA failed from %s/%s: %v", w.cfg.BrokerName, iata, pubkeyHex, err)
 		}

--- a/internal/ingest/packet.go
+++ b/internal/ingest/packet.go
@@ -783,6 +783,12 @@ func (w *Worker) handlePacket(ctx context.Context, iata, pubkeyHex string, raw [
 		}
 	}
 
+	if channelHash != nil && inserted {
+		if err := w.db.UpsertChannelIATA(ctx, channelHash, iata, heardAt); err != nil {
+			log.Printf("ingest[%s]: db: upsert channel IATA failed from %s/%s: %v", w.cfg.BrokerName, iata, pubkeyHex, err)
+		}
+	}
+
 	// packet.PathHashes() reads packet.Path as hash-sized chunks, which is only true for
 	// ordinary flood/direct-routed packets. TRACE repurposes packet.Path to carry one SNR
 	// byte per hop instead, so for TRACE we resolve against the trace payload's own

--- a/internal/ingest/packet.go
+++ b/internal/ingest/packet.go
@@ -790,6 +790,12 @@ func (w *Worker) handlePacket(ctx context.Context, iata, pubkeyHex string, raw [
 		}
 	}
 
+	if traceTag != nil && inserted {
+		if err := w.db.UpsertTraceIATA(ctx, traceTag, iata, heardAt); err != nil {
+			log.Printf("ingest[%s]: db: upsert trace IATA failed from %s/%s: %v", w.cfg.BrokerName, iata, pubkeyHex, err)
+		}
+	}
+
 	// packet.PathHashes() reads packet.Path as hash-sized chunks, which is only true for
 	// ordinary flood/direct-routed packets. TRACE repurposes packet.Path to carry one SNR
 	// byte per hop instead, so for TRACE we resolve against the trace payload's own

--- a/internal/ingest/packet.go
+++ b/internal/ingest/packet.go
@@ -54,6 +54,7 @@ type InsertObservationParams struct {
 	BandwidthKHz      float32
 	CodingRate        int16
 	SourceBroker      string
+	PayloadType       int16
 }
 
 // RadioSettings holds the radio configuration for an observer, populated from
@@ -770,6 +771,7 @@ func (w *Worker) handlePacket(ctx context.Context, iata, pubkeyHex string, raw [
 		BandwidthKHz:      radio.BWKHz,
 		CodingRate:        radio.CR,
 		SourceBroker:      w.cfg.BrokerName,
+		PayloadType:       int16(packet.PayloadType()),
 	}
 	inserted, err := w.db.InsertObservation(ctx, oParams)
 	if err != nil {

--- a/internal/ingest/packet.go
+++ b/internal/ingest/packet.go
@@ -783,7 +783,8 @@ func (w *Worker) handlePacket(ctx context.Context, iata, pubkeyHex string, raw [
 		}
 	}
 
-	if channelHash != nil && inserted {
+	// Runs on duplicate observations too; the upsert only writes when the row is >1h stale.
+	if channelHash != nil {
 		if err := w.db.UpsertChannelIATA(ctx, channelHash, iata, heardAt); err != nil {
 			log.Printf("ingest[%s]: db: upsert channel IATA failed from %s/%s: %v", w.cfg.BrokerName, iata, pubkeyHex, err)
 		}

--- a/internal/ingest/side_effects_test.go
+++ b/internal/ingest/side_effects_test.go
@@ -6,7 +6,10 @@ package ingest
 import (
 	"context"
 	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/MeshCore-Beacon/beacon-server/internal/keystore"
 	"github.com/meshcore-go/meshcore-go"
@@ -131,5 +134,57 @@ func TestHandlePayloadTypeSideEffects_GrpTxt_UnknownKey_OnlyUpsertsHashOnlyChann
 	}
 	if db.upsertChannelCalls != 0 {
 		t.Errorf("expected UpsertChannel NOT to be called when the key is unknown, got %d calls", db.upsertChannelCalls)
+	}
+}
+
+// packetEnvelope wraps a packet in the minimal broker JSON that handlePacket expects.
+func packetEnvelope(t *testing.T, packet *meshcore.Packet) []byte {
+	t.Helper()
+	raw, err := packet.ToBytes()
+	if err != nil {
+		t.Fatalf("packet to bytes: %v", err)
+	}
+	env, err := json.Marshal(map[string]string{
+		"raw":       hex.EncodeToString(raw),
+		"timestamp": time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
+	})
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return env
+}
+
+func TestHandlePacket_GrpTxt_UpsertsChannelIATA(t *testing.T) {
+	w, db := newTestWorker()
+	db.observationInserted = true
+	envelope := packetEnvelope(t, buildGrpTxtPacket(t, 0x1a, make([]byte, 16)))
+
+	w.handlePacket(context.Background(), "YOW", "0102", envelope)
+
+	if db.upsertChannelIATACalls != 1 {
+		t.Errorf("expected UpsertChannelIATA to be called once for a stored group text, got %d", db.upsertChannelIATACalls)
+	}
+}
+
+func TestHandlePacket_GrpTxt_DedupObservation_SkipsChannelIATA(t *testing.T) {
+	w, db := newTestWorker() // stub reports the observation as a duplicate
+	envelope := packetEnvelope(t, buildGrpTxtPacket(t, 0x1a, make([]byte, 16)))
+
+	w.handlePacket(context.Background(), "YOW", "0102", envelope)
+
+	if db.upsertChannelIATACalls != 0 {
+		t.Errorf("expected UpsertChannelIATA NOT to be called for a duplicate observation, got %d calls", db.upsertChannelIATACalls)
+	}
+}
+
+func TestHandlePacket_Advert_SkipsChannelIATA(t *testing.T) {
+	w, db := newTestWorker()
+	db.observationInserted = true
+	envelope := packetEnvelope(t, buildAdvertPacket(t, false))
+
+	w.handlePacket(context.Background(), "YOW", "0102", envelope)
+
+	if db.upsertChannelIATACalls != 0 {
+		t.Errorf("expected UpsertChannelIATA NOT to be called for a non-channel packet, got %d calls", db.upsertChannelIATACalls)
 	}
 }

--- a/internal/ingest/side_effects_test.go
+++ b/internal/ingest/side_effects_test.go
@@ -166,14 +166,14 @@ func TestHandlePacket_GrpTxt_UpsertsChannelIATA(t *testing.T) {
 	}
 }
 
-func TestHandlePacket_GrpTxt_DedupObservation_SkipsChannelIATA(t *testing.T) {
+func TestHandlePacket_GrpTxt_DedupObservation_StillUpsertsChannelIATA(t *testing.T) {
 	w, db := newTestWorker() // stub reports the observation as a duplicate
 	envelope := packetEnvelope(t, buildGrpTxtPacket(t, 0x1a, make([]byte, 16)))
 
 	w.handlePacket(context.Background(), "YOW", "0102", envelope)
 
-	if db.upsertChannelIATACalls != 0 {
-		t.Errorf("expected UpsertChannelIATA NOT to be called for a duplicate observation, got %d calls", db.upsertChannelIATACalls)
+	if db.upsertChannelIATACalls != 1 {
+		t.Errorf("expected UpsertChannelIATA to run for a duplicate observation too, got %d calls", db.upsertChannelIATACalls)
 	}
 }
 

--- a/internal/ingest/side_effects_test.go
+++ b/internal/ingest/side_effects_test.go
@@ -187,4 +187,31 @@ func TestHandlePacket_Advert_SkipsChannelIATA(t *testing.T) {
 	if db.upsertChannelIATACalls != 0 {
 		t.Errorf("expected UpsertChannelIATA NOT to be called for a non-channel packet, got %d calls", db.upsertChannelIATACalls)
 	}
+	if db.upsertTraceIATACalls != 0 {
+		t.Errorf("expected UpsertTraceIATA NOT to be called for a non-trace packet, got %d calls", db.upsertTraceIATACalls)
+	}
+}
+
+func buildTracePacket(t *testing.T) *meshcore.Packet {
+	t.Helper()
+	payload, err := (&meshcore.Trace{Tag: 0xdeadbeef, AuthCode: 1}).ToBytes()
+	if err != nil {
+		t.Fatalf("trace to bytes: %v", err)
+	}
+	return &meshcore.Packet{
+		Header:  meshcore.MakeHeader(meshcore.RouteTypeFlood, meshcore.PayloadTypeTrace, 0),
+		Payload: payload,
+	}
+}
+
+func TestHandlePacket_Trace_UpsertsTraceIATA(t *testing.T) {
+	w, db := newTestWorker()
+	db.observationInserted = true
+	envelope := packetEnvelope(t, buildTracePacket(t))
+
+	w.handlePacket(context.Background(), "YOW", "0102", envelope)
+
+	if db.upsertTraceIATACalls != 1 {
+		t.Errorf("expected UpsertTraceIATA to be called once for a stored trace, got %d", db.upsertTraceIATACalls)
+	}
 }


### PR DESCRIPTION
Fixes the two slow bits on the Analytics tab. Both follow the same pattern already used for top-nodes/hourly stats: precompute into a materialized view refreshed on the existing timer, so the request just reads a small table.

> Stacked on #87 — the first six commits here are that PR. Merge #87 first and this collapses to the two commits below. Review from `track payload_type on observations…` onward.

### Payload Types was 500ing
`GetStatsPayloadBreakdown` joined every observation in the 7-day window back to `packets` just to read `payload_type`. On a busy region that parallel hash over the whole packets table overran the db container's 64MB `/dev/shm` and returned `could not resize shared memory segment ... (SQLSTATE 53100)` — so the panel intermittently 500'd, and when it did succeed it took 4–9s.

- Copy `payload_type` onto the observation at ingest, the same way `source_broker` and the radio fields already are. No more join.
- Backfill is bounded to the last 7 days (all the breakdown reads), so deploy doesn't rewrite the whole 55M-row table.
- Serve it from `mv_payload_breakdown_by_iata` so the request is instant and the (now join-free) aggregate runs on the refresh timer.

### Top Observers was ~2s every load
It scanned 7 days of observations and grouped by observer on every request, and the bitmap went lossy under the 4MB `work_mem`. Now served from `mv_top_observers_by_iata`, same shape as `mv_top_nodes_by_iata`.

### Notes
- Two new refreshes hang off the existing `view_refresh` task; each does the ~2s aggregate in the background instead of on the request.
- `go build ./...`, `go vet`, `go test ./...` all green (12 pkgs).
- The 015 backfill touches a week of rows on deploy — worth an eye, but it's one-time and bounded.
- Migrations 011–014 belong to #87.
