### PR TITLE
fix: cascade channel_messages on packet delete

### DIFF
--- a/db/migrations/023_channel_messages_cascade.sql
+++ b/db/migrations/023_channel_messages_cascade.sql
@@ -1,0 +1,12 @@
+-- Copyright 2026 Beacon Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- The packet_hash FK had no ON DELETE action, so packets carrying a channel
+-- message could never age out and DeleteOldPackets aborted. Match packet_observations.
+
+ALTER TABLE channel_messages
+  DROP CONSTRAINT IF EXISTS channel_messages_packet_hash_fkey;
+
+ALTER TABLE channel_messages
+  ADD CONSTRAINT channel_messages_packet_hash_fkey
+  FOREIGN KEY (packet_hash) REFERENCES packets(packet_hash) ON DELETE CASCADE;


### PR DESCRIPTION
**Suggested title:** Fix packet retention by adding ON DELETE CASCADE to channel_messages FK

## What this PR does

`channel_messages.packet_hash` references `packets` with no `ON DELETE` action, and nothing ever deletes from `channel_messages`. So any packet carrying a channel message can never age out. Since `DeleteOldPackets` is a single statement, one blocked row kills the whole delete:

```
ERROR: update or delete on table "packets" violates foreign key constraint
"channel_messages_packet_hash_fkey" on table "channel_messages" (SQLSTATE 23503)
```

End result is packet retention silently fails every cleanup tick once your channel traffic is older than your retention window. Easy to miss on a newer deployment since nothing has expired yet. I only found it after lowering retention on a DB that had grown to 83 GB.

Migration 023 recreates the FK with `ON DELETE CASCADE`, same as `packet_observations` already does. Channel messages now age out with their packets. Used `DROP CONSTRAINT IF EXISTS` so it stays idempotent if you already patched this by hand.

## Testing notes

Migration only, so `sqlc generate` is a no-op. Verified on a live deployment, both FKs on `packets` now show `confdeltype = 'c'` and the hourly cleanup went from failing every tick to done in a few seconds.

Heads up if your DB has been stuck for a while: the first cleanup after the fix does the entire backlog in one statement and can take a long time. Don't restart the app mid purge, it rolls the whole thing back. And plain DELETE doesn't give space back to the OS, so run a `VACUUM FULL` after if you actually want the files to shrink.