### PR TITLE
fix(api): bound list limits consistently

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4,11 +4,11 @@ package docs
 import "github.com/swaggo/swag"
 
 const docTemplate = `{
-    "schemes": [[ marshal .Schemes ]],
+    "schemes": {{ marshal .Schemes }},
     "swagger": "2.0",
     "info": {
-        "description": "[[escape .Description]]",
-        "title": "[[.Title]]",
+        "description": "{{escape .Description}}",
+        "title": "{{.Title}}",
         "termsOfService": "https://github.com/MeshCore-Beacon/beacon-server",
         "contact": {
             "name": "MeshCore Beacon",
@@ -17,10 +17,10 @@ const docTemplate = `{
         "license": {
             "name": "AGPL-3-or-later"
         },
-        "version": "[[.Version]]"
+        "version": "{{.Version}}"
     },
-    "host": "[[.Host]]",
-    "basePath": "[[.BasePath]]",
+    "host": "{{.Host}}",
+    "basePath": "{{.BasePath}}",
     "paths": {
         "/brokers": {
             "get": {
@@ -79,8 +79,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -201,8 +203,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -387,8 +391,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -457,8 +463,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 100)",
+                        "description": "Max results (default 100); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -583,8 +591,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -718,8 +728,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -817,8 +829,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -909,8 +923,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1090,8 +1106,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1178,8 +1196,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 100)",
+                        "description": "Max results (default 100); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1352,8 +1372,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1366,6 +1388,12 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/github_com_MeshCore-Beacon_beacon-server_internal_api.KnownRoute"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.APIError"
                         }
                     },
                     "500": {
@@ -1612,8 +1640,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1955,8 +1985,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2009,8 +2041,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2069,8 +2103,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2129,8 +2165,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2213,8 +2251,10 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2227,6 +2267,12 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/github_com_MeshCore-Beacon_beacon-server_internal_api.TraceTagSummary"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.APIError"
                         }
                     },
                     "500": {
@@ -3936,8 +3982,8 @@ var SwaggerInfo = &swag.Spec{
 	Description:      "MeshCore network observation backend. Ingests LoRa packets from MQTT brokers, stores in PostgreSQL, and streams live events via WebSocket.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
-	LeftDelim:        "[[",
-	RightDelim:       "]]",
+	LeftDelim:        "{{",
+	RightDelim:       "}}",
 }
 
 func init() {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -77,8 +77,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -199,8 +201,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -385,8 +389,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -455,8 +461,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 100)",
+                        "description": "Max results (default 100); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -581,8 +589,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -716,8 +726,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -815,8 +827,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -907,8 +921,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1088,8 +1104,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1176,8 +1194,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 100)",
+                        "description": "Max results (default 100); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1350,8 +1370,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1364,6 +1386,12 @@
                             "items": {
                                 "$ref": "#/definitions/github_com_MeshCore-Beacon_beacon-server_internal_api.KnownRoute"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.APIError"
                         }
                     },
                     "500": {
@@ -1610,8 +1638,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -1953,8 +1983,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2007,8 +2039,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2067,8 +2101,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2127,8 +2163,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 10)",
+                        "description": "Max results (default 10); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2211,8 +2249,10 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Max results (default 50)",
+                        "description": "Max results (default 50); must be positive, values above 200 are clamped",
                         "name": "limit",
                         "in": "query"
                     }
@@ -2225,6 +2265,12 @@
                             "items": {
                                 "$ref": "#/definitions/github_com_MeshCore-Beacon_beacon-server_internal_api.TraceTagSummary"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.APIError"
                         }
                     },
                     "500": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1177,8 +1177,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1258,8 +1261,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1380,8 +1386,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1426,8 +1435,11 @@ paths:
         in: query
         name: scope
         type: string
-      - description: Max results (default 100)
+      - description: Max results (default 100); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1510,8 +1522,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1598,8 +1613,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1663,8 +1681,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1723,8 +1744,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1845,8 +1869,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -1935,8 +1962,11 @@ paths:
         in: query
         name: scope
         type: string
-      - description: Max results (default 100)
+      - description: Max results (default 100); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2018,8 +2048,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2031,6 +2064,10 @@ paths:
             items:
               $ref: '#/definitions/github_com_MeshCore-Beacon_beacon-server_internal_api.KnownRoute'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_api_handlers.APIError'
         "500":
           description: Internal Server Error
           schema:
@@ -2189,8 +2226,11 @@ paths:
         in: query
         name: region
         type: string
-      - description: Max results (default 10)
+      - description: Max results (default 10); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2412,8 +2452,11 @@ paths:
         in: query
         name: since
         type: integer
-      - description: Max results (default 10)
+      - description: Max results (default 10); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2447,8 +2490,11 @@ paths:
         in: query
         name: region
         type: string
-      - description: Max results (default 10)
+      - description: Max results (default 10); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2486,8 +2532,11 @@ paths:
         in: query
         name: since
         type: integer
-      - description: Max results (default 10)
+      - description: Max results (default 10); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2525,8 +2574,11 @@ paths:
         in: query
         name: since
         type: integer
-      - description: Max results (default 10)
+      - description: Max results (default 10); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2581,8 +2633,11 @@ paths:
         in: query
         name: cursor
         type: integer
-      - description: Max results (default 50)
+      - description: Max results (default 50); must be positive, values above 200
+          are clamped
         in: query
+        maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -2594,6 +2649,10 @@ paths:
             items:
               $ref: '#/definitions/github_com_MeshCore-Beacon_beacon-server_internal_api.TraceTagSummary'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_api_handlers.APIError'
         "500":
           description: Internal Server Error
           schema:

--- a/internal/api/handlers/channels.go
+++ b/internal/api/handlers/channels.go
@@ -38,21 +38,17 @@ func ChannelsRouter(reader api.Reader) http.Handler {
 //	@Param		iata	query		string	false	"Filter by IATA code"
 //	@Param		iatas	query		string	false	"Filter by IATA code(s), comma-separated e.g. YOW or YOW,YYZ"
 //	@Param		cursor	query		int		false	"last_seen epoch ms of last item for pagination"
-//	@Param		limit	query		int		false	"Max results (default 50)"
+//	@Param		limit	query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{object}	api.Page[api.ChannelSummary]
 //	@Failure	400		{object}	handlers.APIError
 //	@Failure	500		{object}	handlers.APIError
 //	@Router		/channels [get]
 func listChannels(reader api.Reader) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var limit int64 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = l
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		iatas := parseIATAs(r)
 		var cursor int64
@@ -77,7 +73,7 @@ func listChannels(reader api.Reader) http.HandlerFunc {
 			}
 			hashHex = h
 		}
-		channels, err := reader.ListChannels(r.Context(), int32(limit), hashHex, iatas, cursor)
+		channels, err := reader.ListChannels(r.Context(), limit, hashHex, iatas, cursor)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "internal server error")
 			return
@@ -128,7 +124,7 @@ func getChannel(reader api.Reader) http.HandlerFunc {
 //	@Param		region		query		string	false	"Filter by region slug, expands to member IATAs"
 //	@Param		scope		query		string	false	"Filter by transport scope name e.g. %23bc (URL-encoded #bc)"
 //	@Param		cursor	query		int		false	"Message ID of last item for pagination (results ordered newest first)"
-//	@Param		limit		query		int		false	"Max results (default 50)"
+//	@Param		limit		query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200			{object}	object
 //	@Failure	400			{object}	handlers.APIError
 //	@Failure	500			{object}	handlers.APIError
@@ -144,14 +140,10 @@ func listChannelMessages(reader api.Reader) http.HandlerFunc {
 			}
 			id = i
 		}
-		var limit int64 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = l
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		var since time.Time
 		if sinceParam := r.URL.Query().Get("since"); sinceParam != "" {
@@ -174,7 +166,7 @@ func listChannelMessages(reader api.Reader) http.HandlerFunc {
 		}
 		scope := r.URL.Query().Get("scope")
 		chanID := int32(id)
-		messages, err := reader.ListChannelMessages(r.Context(), &chanID, since, int32(limit), iatas, scope, cursor)
+		messages, err := reader.ListChannelMessages(r.Context(), &chanID, since, limit, iatas, scope, cursor)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "internal server error")
 			return

--- a/internal/api/handlers/limits.go
+++ b/internal/api/handlers/limits.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+const maxListLimit int32 = 200
+
+// parseLimit caps the requested result size while retaining each endpoint's default.
+func parseLimit(r *http.Request, defaultLimit int32) (int32, error) {
+	value := r.URL.Query().Get("limit")
+	if value == "" {
+		return defaultLimit, nil
+	}
+	limit, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, errors.New("limit must be an integer")
+	}
+	if limit <= 0 {
+		return 0, errors.New("limit must be positive")
+	}
+	if limit > int64(maxListLimit) {
+		log.Printf("api: clamped list limit from %d to %d for %s on %s", limit, maxListLimit, r.RemoteAddr, r.URL.Path)
+		return maxListLimit, nil
+	}
+	return int32(limit), nil
+}

--- a/internal/api/handlers/limits_test.go
+++ b/internal/api/handlers/limits_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MeshCore-Beacon/beacon-server/internal/api"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+func TestListLimits(t *testing.T) {
+	var got int32
+	var calls int
+	reader := stubReader{
+		listChannels: func(ctx context.Context, limit int32, hash []byte, iatas []string, cursor int64) (api.Page[api.ChannelSummary], error) {
+			calls++
+			got = limit
+			return api.Page[api.ChannelSummary]{}, nil
+		},
+		listChannelMessages: func(ctx context.Context, channelID *int32, since time.Time, limit int32, iatas []string, scope string, cursor int64) (api.Page[api.ChannelMessage], error) {
+			calls++
+			got = limit
+			return api.Page[api.ChannelMessage]{}, nil
+		},
+		listChannelMessagesByHash: func(ctx context.Context, hash []byte, since time.Time, limit int32, iatas []string, scope string, cursor int64) (api.Page[api.ChannelMessage], error) {
+			calls++
+			got = limit
+			return api.Page[api.ChannelMessage]{}, nil
+		},
+		listMessagesAfterID: func(ctx context.Context, afterID int64, iatas []string, scope string, limit int32) ([]api.ChannelMessage, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		listObservers: func(ctx context.Context, iatas []string, observerType, broker, status, name, scope string, cursor int64, limit int32) (api.Page[api.ObserverSummary], error) {
+			calls++
+			got = limit
+			return api.Page[api.ObserverSummary]{}, nil
+		},
+		listObserverAdverts: func(ctx context.Context, observerID uuid.UUID, cursor int64, limit int32) (api.Page[api.AdvertObservation], error) {
+			calls++
+			got = limit
+			return api.Page[api.AdvertObservation]{}, nil
+		},
+		listNodes: func(ctx context.Context, nodeType int16, iatas []string, supportsMultibytePaths, supportsMultibyteTraces *bool, pubkey []byte, pubkeyPrefix, name, scope string, cursor int64, limit int32, includeNeighbors bool) (api.Page[api.NodeSummary], error) {
+			calls++
+			got = limit
+			return api.Page[api.NodeSummary]{}, nil
+		},
+		listNodeObservations: func(ctx context.Context, nodeID uuid.UUID, cursor int64, limit int32) (api.Page[api.PacketObservationSummary], error) {
+			calls++
+			got = limit
+			return api.Page[api.PacketObservationSummary]{}, nil
+		},
+		listPackets: func(ctx context.Context, payloadTypes, routeTypes []int16, iatas []string, scopes []string, since, until time.Time, cursor int64, limit int32) (api.Page[api.PacketSummary], error) {
+			calls++
+			got = limit
+			return api.Page[api.PacketSummary]{}, nil
+		},
+		listPacketsAfterID: func(ctx context.Context, afterObservationID int64, payloadType, routeType int16, iatas []string, scope string, limit int32) ([]api.PacketSummary, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		getStatsTopNodes: func(ctx context.Context, iatas []string, limit int32) ([]api.TopNode, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		getStatsTopObservers: func(ctx context.Context, iatas []string, since time.Time, limit int32) ([]api.TopObserver, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		getStatsTopAdvertisers: func(ctx context.Context, iatas []string, since time.Time, limit int32) ([]api.TopAdvertiser, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		getStatsClockDrift: func(ctx context.Context, iatas []string, limit int32) ([]api.ClockDriftEntry, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		getStatsTopTalkers: func(ctx context.Context, iatas []string, since time.Time, limit int32) ([]api.TopTalker, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		listTraceTags: func(ctx context.Context, iatas []string, scope, traceType string, since, until time.Time, cursor time.Time, limit int32) ([]api.TraceTagSummary, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+		listKnownRoutes: func(ctx context.Context, iata string, hopCount int32, cursor time.Time, limit int32) ([]api.KnownRoute, error) {
+			calls++
+			got = limit
+			return nil, nil
+		},
+	}
+	router := chi.NewRouter()
+	router.Mount("/nodes", NodesRouter(reader))
+	router.Mount("/observers", ObserversRouter(reader))
+	router.Mount("/packets", PacketsRouter(reader))
+	router.Mount("/channels", ChannelsRouter(reader))
+	router.Mount("/messages", MessagesRouter(reader))
+	router.Mount("/routes", RoutesRouter(reader))
+	router.Mount("/traces", TracesRouter(reader))
+	router.Mount("/stats", StatsRouter(reader))
+	for _, endpoint := range []struct {
+		path         string
+		defaultLimit int32
+	}{
+		{"/nodes", 50},
+		{"/nodes/00000000-0000-0000-0000-000000000001/observations", 50},
+		{"/observers", 50},
+		{"/observers/00000000-0000-0000-0000-000000000001/adverts", 50},
+		{"/packets", 50},
+		{"/packets/backfill?afterObservationId=1", 100},
+		{"/channels", 50},
+		{"/channels/1/messages", 50},
+		{"/messages", 50},
+		{"/messages?channelHash=11", 50},
+		{"/messages/backfill?afterId=1", 100},
+		{"/routes", 50},
+		{"/traces", 50},
+		{"/stats/top-nodes", 10},
+		{"/stats/top-observers", 10},
+		{"/stats/top-advertisers", 10},
+		{"/stats/clock-drift", 10},
+		{"/stats/top-talkers", 10},
+	} {
+		t.Run(endpoint.path, func(t *testing.T) {
+			for _, tc := range []struct {
+				value  string
+				want   int32
+				status int
+			}{
+				{"", endpoint.defaultLimit, 200}, {"1", 1, 200}, {"200", 200, 200},
+				{"201", 200, 200}, {"1000000", 200, 200}, {"2147483647", 200, 200},
+				{"0", 0, 400}, {"-1", 0, 400}, {"bad", 0, 400}, {"1.5", 0, 400},
+				{"2147483648", 0, 400},
+			} {
+				t.Run(tc.value, func(t *testing.T) {
+					got, calls = 0, 0
+					req := httptest.NewRequest(http.MethodGet, endpoint.path, nil)
+					query := req.URL.Query()
+					query.Set("limit", tc.value)
+					req.URL.RawQuery = query.Encode()
+					rec := httptest.NewRecorder()
+					router.ServeHTTP(rec, req)
+					if rec.Code != tc.status {
+						t.Fatalf("status %d, want %d: %s", rec.Code, tc.status, rec.Body.String())
+					}
+					if tc.status == http.StatusBadRequest {
+						if calls != 0 {
+							t.Fatal("invalid limit reached the reader")
+						}
+					} else if calls != 1 || got != tc.want {
+						t.Fatalf("reader calls=%d limit=%d, want 1 and %d", calls, got, tc.want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/api/handlers/messages.go
+++ b/internal/api/handlers/messages.go
@@ -37,7 +37,7 @@ func MessagesRouter(reader api.Reader) http.Handler {
 //	@Param		region		query		string	false	"Filter by region slug, expands to member IATAs"
 //	@Param		scope		query		string	false	"Filter by transport scope name e.g. %23bc (URL-encoded #bc)"
 //	@Param		cursor	query		int		false	"Message ID of last item for pagination (results ordered newest first)"
-//	@Param		limit		query		int		false	"Max results (default 50)"
+//	@Param		limit		query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200			{object}	object
 //	@Failure	400			{object}	handlers.APIError
 //	@Failure	500			{object}	handlers.APIError
@@ -60,14 +60,10 @@ func listMessages(reader api.Reader) http.HandlerFunc {
 			}
 			id = i
 		}
-		var limit int64 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = l
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		var since time.Time
 		if sinceParam := r.URL.Query().Get("since"); sinceParam != "" {
@@ -90,7 +86,6 @@ func listMessages(reader api.Reader) http.HandlerFunc {
 		iatas := parseIATAs(r)
 		scope := r.URL.Query().Get("scope")
 		var messages api.Page[api.ChannelMessage]
-		var err error
 		if channelHashParam != "" {
 			hashHex, decodeErr := hex.DecodeString(channelHashParam)
 			if decodeErr != nil {
@@ -101,12 +96,12 @@ func listMessages(reader api.Reader) http.HandlerFunc {
 				respondError(w, http.StatusBadRequest, "channel hash must be a single hex byte")
 				return
 			}
-			messages, err = reader.ListChannelMessagesByHash(r.Context(), hashHex, since, int32(limit), iatas, scope, cursor)
+			messages, err = reader.ListChannelMessagesByHash(r.Context(), hashHex, since, limit, iatas, scope, cursor)
 		} else if channelIDParam != "" {
 			chanID := int32(id)
-			messages, err = reader.ListChannelMessages(r.Context(), &chanID, since, int32(limit), iatas, scope, cursor)
+			messages, err = reader.ListChannelMessages(r.Context(), &chanID, since, limit, iatas, scope, cursor)
 		} else {
-			messages, err = reader.ListChannelMessages(r.Context(), nil, since, int32(limit), iatas, scope, cursor)
+			messages, err = reader.ListChannelMessages(r.Context(), nil, since, limit, iatas, scope, cursor)
 		}
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "internal server error")
@@ -126,7 +121,7 @@ func listMessages(reader api.Reader) http.HandlerFunc {
 //	@Param		region		query		string	false	"Filter by region slug"
 //	@Param		regionId	query		int		false	"Filter by region ID"
 //	@Param		scope		query		string	false	"Filter by transport scope name"
-//	@Param		limit		query		int		false	"Max results (default 100)"
+//	@Param		limit		query		int		false	"Max results (default 100); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200			{object}	[]api.ChannelMessage
 //	@Failure	400			{object}	handlers.APIError
 //	@Failure	500			{object}	handlers.APIError
@@ -143,14 +138,10 @@ func listMessagesBackfill(reader api.Reader) http.HandlerFunc {
 			respondError(w, http.StatusBadRequest, "afterId must be an integer")
 			return
 		}
-		var limit int32 = 100
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 100)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		iatas := parseIATAs(r)
 		if regionIDStr := r.URL.Query().Get("regionId"); regionIDStr != "" || r.URL.Query().Get("region") != "" {

--- a/internal/api/handlers/nodes.go
+++ b/internal/api/handlers/nodes.go
@@ -49,7 +49,7 @@ func NodesRouter(reader api.Reader) http.Handler {
 //	@Param		supportsMultibyteTraces	query		bool	false	"Filter by multibyte trace support (true/false); omit for no filter"
 //	@Param		neighbors				query		bool	false	"Include each node's known neighbor IDs (neighborIds field). Bare ?neighbors or ?neighbors=true enables it; omit/false for none"
 //	@Param		cursor					query		int		false	"last_seen epoch ms of last item for pagination"
-//	@Param		limit					query		int		false	"Max results (default 50)"
+//	@Param		limit					query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200						{object}	api.Page[api.NodeSummary]
 //	@Failure	400						{object}	handlers.APIError
 //	@Failure	500						{object}	handlers.APIError
@@ -67,14 +67,10 @@ func listNodes(reader api.Reader) http.HandlerFunc {
 		} else if typeName := r.URL.Query().Get("typeName"); typeName != "" {
 			nodeType = api.NodeTypeFromString(typeName)
 		}
-		var limit int32 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		var cursor int64
 		if cursorParam := r.URL.Query().Get("cursor"); cursorParam != "" {
@@ -184,7 +180,7 @@ func getNode(reader api.Reader) http.HandlerFunc {
 //	@Produce	json
 //	@Param		nodeId	path		string	true	"Node UUID"
 //	@Param		cursor	query		int		false	"Observation ID of last item for pagination"
-//	@Param		limit	query		int		false	"Max results (default 50)"
+//	@Param		limit	query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{object}	api.Page[api.PacketObservationSummary]
 //	@Failure	400		{object}	handlers.APIError
 //	@Failure	500		{object}	handlers.APIError
@@ -205,14 +201,10 @@ func listNodeObservations(reader api.Reader) http.HandlerFunc {
 			}
 			cursor = c
 		}
-		var limit int32 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		observations, err := reader.ListNodeObservations(r.Context(), nodeID, cursor, limit)
 		if err != nil {

--- a/internal/api/handlers/observers.go
+++ b/internal/api/handlers/observers.go
@@ -45,7 +45,7 @@ func ObserversRouter(reader api.Reader) http.Handler {
 //	@Param		name	query		string	false	"Partial case-insensitive display name match"
 //	@Param		scope	query		string	false	"Filter by transport scope name e.g. %23bc (URL-encoded #bc)"
 //	@Param		cursor	query		int		false	"last_seen epoch ms of last item for pagination"
-//	@Param		limit	query		int		false	"Max results (default 50)"
+//	@Param		limit	query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{object}	api.Page[api.ObserverSummary]
 //	@Failure	400		{object}	handlers.APIError
 //	@Failure	500		{object}	handlers.APIError
@@ -66,14 +66,10 @@ func listObservers(reader api.Reader) http.HandlerFunc {
 			}
 			cursor = c
 		}
-		var limit int32 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		iatas := parseIATAs(r)
 		if regionIDStr := r.URL.Query().Get("regionId"); regionIDStr != "" || r.URL.Query().Get("region") != "" {
@@ -127,7 +123,7 @@ func getObserver(reader api.Reader) http.HandlerFunc {
 //	@Produce	json
 //	@Param		observerId	path		string	true	"Observer UUID"
 //	@Param		cursor		query		int		false	"Observation ID of last item for pagination"
-//	@Param		limit		query		int		false	"Max results (default 50)"
+//	@Param		limit		query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200			{object}	api.Page[api.AdvertObservation]
 //	@Failure	400			{object}	handlers.APIError
 //	@Failure	500			{object}	handlers.APIError
@@ -148,14 +144,10 @@ func listObserverAdverts(reader api.Reader) http.HandlerFunc {
 			}
 			cursor = c
 		}
-		var limit int32 = 50
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		adverts, err := reader.ListObserverAdverts(r.Context(), observerID, cursor, limit)
 		if err != nil {

--- a/internal/api/handlers/packets.go
+++ b/internal/api/handlers/packets.go
@@ -45,7 +45,7 @@ func PacketsRouter(reader api.Reader) http.Handler {
 //	@Param		since			query		int		false	"Filter by first_heard_at >= since (epoch ms)"
 //	@Param		until			query		int		false	"Filter by first_heard_at <= until (epoch ms)"
 //	@Param		cursor			query		int		false	"epoch ms of last item for pagination; last_heard_at, or site-local heard_at when iatas is set"
-//	@Param		limit			query		int		false	"Max results (default 50)"
+//	@Param		limit			query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200				{object}	object
 //	@Failure	400				{object}	handlers.APIError
 //	@Failure	500				{object}	handlers.APIError
@@ -93,14 +93,10 @@ func listPackets(reader api.Reader) http.HandlerFunc {
 			}
 			cursor = c
 		}
-		var limit int32 = 50
-		if p := r.URL.Query().Get("limit"); p != "" {
-			l, err := strconv.ParseInt(p, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		iatas := parseIATAs(r)
 		if regionIDStr := r.URL.Query().Get("regionId"); regionIDStr != "" || r.URL.Query().Get("region") != "" {
@@ -134,7 +130,7 @@ func listPackets(reader api.Reader) http.HandlerFunc {
 //	@Param		region				query		string	false	"Filter by region slug"
 //	@Param		regionId			query		int		false	"Filter by region ID"
 //	@Param		scope				query		string	false	"Filter by transport scope name"
-//	@Param		limit				query		int		false	"Max results (default 100)"
+//	@Param		limit				query		int		false	"Max results (default 100); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200					{object}	[]api.PacketSummary
 //	@Failure	400					{object}	handlers.APIError
 //	@Failure	500					{object}	handlers.APIError
@@ -151,14 +147,10 @@ func listPacketsBackfill(reader api.Reader) http.HandlerFunc {
 			respondError(w, http.StatusBadRequest, "afterObservationId must be an integer")
 			return
 		}
-		var limit int32 = 100
-		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
-			l, err := strconv.ParseInt(limitParam, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 100)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		var payloadType int16 = -1
 		if v := r.URL.Query().Get("payloadType"); v != "" {

--- a/internal/api/handlers/routes.go
+++ b/internal/api/handlers/routes.go
@@ -33,7 +33,8 @@ func RoutesRouter(reader api.Reader) http.Handler {
 //	@Param		iata		query		string	false	"Filter by IATA code"
 //	@Param		hopCount	query		int		false	"Filter by exact hop count"
 //	@Param		cursor		query		int		false	"Epoch ms timestamp of last item for pagination"
-//	@Param		limit		query		int		false	"Max results (default 50)"
+//	@Param		limit		query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
+//	@Failure	400			{object}	handlers.APIError
 //	@Success	200			{object}	[]api.KnownRoute
 //	@Failure	500			{object}	handlers.APIError
 //	@Router		/routes [get]
@@ -52,11 +53,10 @@ func listKnownRoutes(reader api.Reader) http.HandlerFunc {
 				cursor = time.UnixMilli(ms)
 			}
 		}
-		var limit int32 = 50
-		if v := r.URL.Query().Get("limit"); v != "" {
-			if l, err := strconv.ParseInt(v, 10, 32); err == nil {
-				limit = int32(l)
-			}
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		routes, err := reader.ListKnownRoutes(r.Context(), iata, hopCount, cursor, limit)
 		if err != nil {

--- a/internal/api/handlers/stats.go
+++ b/internal/api/handlers/stats.go
@@ -166,7 +166,7 @@ func getStatsPayloadBreakdown(reader api.Reader) http.HandlerFunc {
 //	@Param		iatas		query	string	false	"Comma-separated IATA codes"
 //	@Param		regionId	query	int		false	"Filter by region ID, expands to member IATAs"
 //	@Param		region		query	string	false	"Filter by region slug, expands to member IATAs"
-//	@Param		limit	query		int		false	"Max results (default 10)"
+//	@Param		limit	query		int		false	"Max results (default 10); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{array}		api.TopNode
 //	@Failure	500		{object}	handlers.APIError
 //	@Router		/stats/top-nodes [get]
@@ -181,14 +181,10 @@ func getStatsTopNodes(reader api.Reader) http.HandlerFunc {
 			}
 			iatas = append(iatas, regionIATAs...)
 		}
-		var limit int32 = 10
-		if p := r.URL.Query().Get("limit"); p != "" {
-			l, err := strconv.ParseInt(p, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 10)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		nodes, err := reader.GetStatsTopNodes(r.Context(), iatas, limit)
 		if err != nil {
@@ -209,7 +205,7 @@ func getStatsTopNodes(reader api.Reader) http.HandlerFunc {
 //	@Param		regionId	query	int		false	"Filter by region ID, expands to member IATAs"
 //	@Param		region		query	string	false	"Filter by region slug, expands to member IATAs"
 //	@Param		since	query		int		false	"Start of window epoch ms (default last 24h)"
-//	@Param		limit	query		int		false	"Max results (default 10)"
+//	@Param		limit	query		int		false	"Max results (default 10); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{array}		api.TopObserver
 //	@Failure	500		{object}	handlers.APIError
 //	@Router		/stats/top-observers [get]
@@ -233,14 +229,10 @@ func getStatsTopObservers(reader api.Reader) http.HandlerFunc {
 			}
 			since = time.UnixMilli(ms)
 		}
-		var limit int32 = 10
-		if p := r.URL.Query().Get("limit"); p != "" {
-			l, err := strconv.ParseInt(p, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 10)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		observers, err := reader.GetStatsTopObservers(r.Context(), iatas, since, limit)
 		if err != nil {
@@ -261,7 +253,7 @@ func getStatsTopObservers(reader api.Reader) http.HandlerFunc {
 //	@Param		regionId	query	int		false	"Filter by region ID, expands to member IATAs"
 //	@Param		region		query	string	false	"Filter by region slug, expands to member IATAs"
 //	@Param		since	query		int		false	"Start of window epoch ms (default last 24h)"
-//	@Param		limit	query		int		false	"Max results (default 10)"
+//	@Param		limit	query		int		false	"Max results (default 10); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{array}		api.TopAdvertiser
 //	@Failure	500		{object}	handlers.APIError
 //	@Router		/stats/top-advertisers [get]
@@ -285,14 +277,10 @@ func getStatsTopAdvertisers(reader api.Reader) http.HandlerFunc {
 			}
 			since = time.UnixMilli(ms)
 		}
-		var limit int32 = 10
-		if p := r.URL.Query().Get("limit"); p != "" {
-			l, err := strconv.ParseInt(p, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 10)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		advertisers, err := reader.GetStatsTopAdvertisers(r.Context(), iatas, since, limit)
 		if err != nil {
@@ -312,7 +300,7 @@ func getStatsTopAdvertisers(reader api.Reader) http.HandlerFunc {
 //	@Param		iatas		query	string	false	"Comma-separated IATA codes"
 //	@Param		regionId	query	int		false	"Filter by region ID, expands to member IATAs"
 //	@Param		region		query	string	false	"Filter by region slug, expands to member IATAs"
-//	@Param		limit	query		int		false	"Max results (default 10)"
+//	@Param		limit	query		int		false	"Max results (default 10); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{array}		api.ClockDriftEntry
 //	@Failure	500		{object}	handlers.APIError
 //	@Router		/stats/clock-drift [get]
@@ -327,14 +315,10 @@ func getStatsClockDrift(reader api.Reader) http.HandlerFunc {
 			}
 			iatas = append(iatas, regionIATAs...)
 		}
-		var limit int32 = 10
-		if p := r.URL.Query().Get("limit"); p != "" {
-			l, err := strconv.ParseInt(p, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 10)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		entries, err := reader.GetStatsClockDrift(r.Context(), iatas, limit)
 		if err != nil {
@@ -355,7 +339,7 @@ func getStatsClockDrift(reader api.Reader) http.HandlerFunc {
 //	@Param		regionId	query	int		false	"Filter by region ID, expands to member IATAs"
 //	@Param		region		query	string	false	"Filter by region slug, expands to member IATAs"
 //	@Param		since	query		int		false	"Start of window epoch ms (default last 24h)"
-//	@Param		limit	query		int		false	"Max results (default 10)"
+//	@Param		limit	query		int		false	"Max results (default 10); must be positive, values above 200 are clamped" minimum(1) maximum(200)
 //	@Success	200		{array}		api.TopTalker
 //	@Failure	500		{object}	handlers.APIError
 //	@Router		/stats/top-talkers [get]
@@ -379,14 +363,10 @@ func getStatsTopTalkers(reader api.Reader) http.HandlerFunc {
 			}
 			since = time.UnixMilli(ms)
 		}
-		var limit int32 = 10
-		if p := r.URL.Query().Get("limit"); p != "" {
-			l, err := strconv.ParseInt(p, 10, 32)
-			if err != nil {
-				respondError(w, http.StatusBadRequest, "limit must be an integer")
-				return
-			}
-			limit = int32(l)
+		limit, err := parseLimit(r, 10)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		talkers, err := reader.GetStatsTopTalkers(r.Context(), iatas, since, limit)
 		if err != nil {

--- a/internal/api/handlers/traces.go
+++ b/internal/api/handlers/traces.go
@@ -37,17 +37,17 @@ func TracesRouter(reader api.Reader) http.Handler {
 //	@Param		since		query		int		false	"Filter by first_heard_at >= since (epoch ms)"
 //	@Param		until		query		int		false	"Filter by first_heard_at <= until (epoch ms)"
 //	@Param		cursor		query		int		false	"last_heard_at epoch ms of last item for pagination"
-//	@Param		limit		query		int		false	"Max results (default 50)"
+//	@Param		limit		query		int		false	"Max results (default 50); must be positive, values above 200 are clamped" minimum(1) maximum(200)
+//	@Failure	400			{object}	handlers.APIError
 //	@Success	200			{object}	[]api.TraceTagSummary
 //	@Failure	500			{object}	handlers.APIError
 //	@Router		/traces [get]
 func listTraceTags(reader api.Reader) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var limit int32 = 50
-		if l := r.URL.Query().Get("limit"); l != "" {
-			if v, err := strconv.ParseInt(l, 10, 32); err == nil {
-				limit = int32(v)
-			}
+		limit, err := parseLimit(r, 50)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		var since, until, cursor time.Time
 		if v := r.URL.Query().Get("since"); v != "" {


### PR DESCRIPTION
## What this PR does

Closes #102. Apply one limit policy to all 17 existing limit-bearing handlers: keep endpoint defaults, reject malformed or nonpositive limits with HTTP 400, and clamp valid oversized values to 200 before invoking the reader. Clamped requests are logged. Routes and traces now reject malformed limits consistently with the other lists.

This bounds requested result sizes and avoids `limit + 1` overflow in paginated store methods. It does not impose a query execution timeout or request rate limit. The current web dev client uses page sizes within the cap, including its 200-row trace request.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Docs / config

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New parsing logic has regression coverage through every affected handler
- [x] Swagger annotations updated and docs regenerated with swag v1.16.6
- [x] No database schema or dependency change
- [x] I have read `CONTRIBUTING.md`

## Testing notes

The table-driven endpoint regression covers defaults, 1, 200, 201, one million, max int32, zero, negatives, malformed values and overflow. Invalid values must not reach the reader. It fails against the original handlers and passes with this change. Both message lookup paths are exercised.

Native ARM64 build and complete regular test suite passed on Pi 5. Handler race tests passed on Windows/amd64. Pi's ThreadSanitizer exits before tests with an unsupported virtual-memory-layout error. The dev-MQTT runtime check verifies real ingestion, both broker connections, normal API requests and invalid/oversized node limits. Development-feed smoke tests do not certify production-scale throughput.

AI tools assisted this implementation. The contributor reviewed and approved the diff and test evidence before submission.

A [combined development preview](https://canadaverse.org/beacon-dev/) includes PRs #111, #112, #113 and #115. Its [source and build details](https://canadaverse.org/beacon-dev/source.html) identify the exact build. MQTT keepalive reconnects are tracked separately in #116.
