### PR TITLE
fix(background): preserve refresh failures in task outcomes

### DIFF
--- a/internal/background/background.go
+++ b/internal/background/background.go
@@ -38,9 +38,10 @@ func (s *Scheduler) Start(ctx context.Context) {
 				case <-ticker.C:
 					log.Printf("background[%s]: running", t.Name)
 					if err := t.Run(ctx); err != nil {
-						log.Printf("background[%s]: %v", t.Name, err)
+						log.Printf("background[%s]: failed: %v", t.Name, err)
+					} else {
+						log.Printf("background[%s]: complete", t.Name)
 					}
-					log.Printf("background[%s]: complete", t.Name)
 				case <-ctx.Done():
 					return
 				}

--- a/internal/background/background_test.go
+++ b/internal/background/background_test.go
@@ -7,98 +7,108 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
 func TestScheduler_RunsTask(t *testing.T) {
-	var calls atomic.Int32
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
 
-	tasks := []Task{
-		{
-			Name:     "test-task",
-			Interval: 10 * time.Millisecond,
-			Run: func(ctx context.Context) error {
-				calls.Add(1)
-				return nil
+		tasks := []Task{
+			{
+				Name:     "test-task",
+				Interval: 10 * time.Millisecond,
+				Run: func(ctx context.Context) error {
+					calls.Add(1)
+					return nil
+				},
 			},
-		},
-	}
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	s := New(tasks)
-	go s.Start(ctx)
+		s := New(tasks)
+		go s.Start(ctx)
 
-	time.Sleep(50 * time.Millisecond)
-	if calls.Load() == 0 {
-		t.Error("expected task to have run at least once")
-	}
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+		if calls.Load() == 0 {
+			t.Error("expected task to have run at least once")
+		}
+	})
 }
 
 func TestScheduler_StopsOnContextCancel(t *testing.T) {
-	var calls atomic.Int32
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
 
-	tasks := []Task{
-		{
-			Name:     "test-task",
-			Interval: 10 * time.Millisecond,
-			Run: func(ctx context.Context) error {
-				calls.Add(1)
-				return nil
+		tasks := []Task{
+			{
+				Name:     "test-task",
+				Interval: 10 * time.Millisecond,
+				Run: func(ctx context.Context) error {
+					calls.Add(1)
+					return nil
+				},
 			},
-		},
-	}
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	s := New(tasks)
-	go s.Start(ctx)
+		ctx, cancel := context.WithCancel(context.Background())
+		s := New(tasks)
+		go s.Start(ctx)
 
-	time.Sleep(30 * time.Millisecond)
-	cancel()
-	time.Sleep(10 * time.Millisecond)
+		time.Sleep(30 * time.Millisecond)
+		synctest.Wait()
+		cancel()
+		synctest.Wait()
 
-	snapshot := calls.Load()
-	time.Sleep(30 * time.Millisecond)
+		snapshot := calls.Load()
+		time.Sleep(30 * time.Millisecond)
 
-	if calls.Load() != snapshot {
-		t.Errorf("expected task to stop after cancel, got %d more calls", calls.Load()-snapshot)
-	}
+		if calls.Load() != snapshot {
+			t.Errorf("expected task to stop after cancel, got %d more calls", calls.Load()-snapshot)
+		}
+	})
 }
 
 func TestScheduler_MultipleTasksRunIndependently(t *testing.T) {
-	var calls1, calls2 atomic.Int32
+	synctest.Test(t, func(t *testing.T) {
+		var calls1, calls2 atomic.Int32
 
-	tasks := []Task{
-		{
-			Name:     "task1",
-			Interval: 10 * time.Millisecond,
-			Run: func(ctx context.Context) error {
-				calls1.Add(1)
-				return nil
+		tasks := []Task{
+			{
+				Name:     "task1",
+				Interval: 10 * time.Millisecond,
+				Run: func(ctx context.Context) error {
+					calls1.Add(1)
+					return nil
+				},
 			},
-		},
-		{
-			Name:     "task2",
-			Interval: 10 * time.Millisecond,
-			Run: func(ctx context.Context) error {
-				calls2.Add(1)
-				return nil
+			{
+				Name:     "task2",
+				Interval: 10 * time.Millisecond,
+				Run: func(ctx context.Context) error {
+					calls2.Add(1)
+					return nil
+				},
 			},
-		},
-	}
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	s := New(tasks)
-	go s.Start(ctx)
+		s := New(tasks)
+		go s.Start(ctx)
 
-	time.Sleep(50 * time.Millisecond)
-	if calls1.Load() == 0 {
-		t.Error("expected task1 to have run")
-	}
-	if calls2.Load() == 0 {
-		t.Error("expected task2 to have run")
-	}
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+		if calls1.Load() == 0 {
+			t.Error("expected task1 to have run")
+		}
+		if calls2.Load() == 0 {
+			t.Error("expected task2 to have run")
+		}
+	})
 }

--- a/internal/background/tasks.go
+++ b/internal/background/tasks.go
@@ -5,41 +5,47 @@ package background
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/MeshCore-Beacon/beacon-server/db"
 )
 
+type viewRefresher interface {
+	RefreshHourlyStats(context.Context) error
+	RefreshTopNodes(context.Context) error
+	RefreshTopObservers(context.Context) error
+	RefreshPayloadBreakdown(context.Context) error
+	RefreshTopTalkers(context.Context) error
+	RefreshTopAdvertisers(context.Context) error
+	RefreshRadioPresets(context.Context) error
+}
+
 // ViewRefreshTask returns a Task that refreshes all materialized views.
-func ViewRefreshTask(store *db.Store, interval time.Duration) Task {
+func ViewRefreshTask(store viewRefresher, interval time.Duration) Task {
 	return Task{
 		Name:     "view_refresh",
 		Interval: interval,
 		Run: func(ctx context.Context) error {
-			if err := store.RefreshHourlyStats(ctx); err != nil {
-				log.Printf("background[view_refresh]: hourly stats: %v", err)
+			var errs []error
+			for _, view := range []struct {
+				name    string
+				refresh func(context.Context) error
+			}{
+				{"hourly stats", store.RefreshHourlyStats},
+				{"top nodes", store.RefreshTopNodes},
+				{"top observers", store.RefreshTopObservers},
+				{"payload breakdown", store.RefreshPayloadBreakdown},
+				{"top talkers", store.RefreshTopTalkers},
+				{"top advertisers", store.RefreshTopAdvertisers},
+				{"radio presets", store.RefreshRadioPresets},
+			} {
+				if err := view.refresh(ctx); err != nil {
+					errs = append(errs, fmt.Errorf("%s: %w", view.name, err))
+				}
 			}
-			if err := store.RefreshTopNodes(ctx); err != nil {
-				log.Printf("background[view_refresh]: top nodes: %v", err)
-			}
-			if err := store.RefreshTopObservers(ctx); err != nil {
-				log.Printf("background[view_refresh]: top observers: %v", err)
-			}
-			if err := store.RefreshPayloadBreakdown(ctx); err != nil {
-				log.Printf("background[view_refresh]: payload breakdown: %v", err)
-			}
-			if err := store.RefreshTopTalkers(ctx); err != nil {
-				log.Printf("background[view_refresh]: top talkers: %v", err)
-			}
-			if err := store.RefreshTopAdvertisers(ctx); err != nil {
-				log.Printf("background[view_refresh]: top advertisers: %v", err)
-			}
-			if err := store.RefreshRadioPresets(ctx); err != nil {
-				log.Printf("background[view_refresh]: radio presets: %v", err)
-			}
-			return nil
+			return errors.Join(errs...)
 		},
 	}
 }

--- a/internal/background/tasks_test.go
+++ b/internal/background/tasks_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package background
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+type refreshStub struct {
+	calls []string
+	errs  map[string]error
+}
+
+func (s *refreshStub) refresh(ctx context.Context, name string) error {
+	s.calls = append(s.calls, name)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.errs[name]
+}
+func (s *refreshStub) RefreshHourlyStats(ctx context.Context) error {
+	return s.refresh(ctx, "hourly stats")
+}
+func (s *refreshStub) RefreshTopNodes(ctx context.Context) error { return s.refresh(ctx, "top nodes") }
+func (s *refreshStub) RefreshTopObservers(ctx context.Context) error {
+	return s.refresh(ctx, "top observers")
+}
+func (s *refreshStub) RefreshPayloadBreakdown(ctx context.Context) error {
+	return s.refresh(ctx, "payload breakdown")
+}
+func (s *refreshStub) RefreshTopTalkers(ctx context.Context) error {
+	return s.refresh(ctx, "top talkers")
+}
+func (s *refreshStub) RefreshTopAdvertisers(ctx context.Context) error {
+	return s.refresh(ctx, "top advertisers")
+}
+func (s *refreshStub) RefreshRadioPresets(ctx context.Context) error {
+	return s.refresh(ctx, "radio presets")
+}
+
+func TestViewRefreshTask(t *testing.T) {
+	first, second := errors.New("first failure"), errors.New("second failure")
+	for _, tc := range []struct {
+		name string
+		errs map[string]error
+	}{
+		{"success", nil},
+		{"partial failure", map[string]error{"hourly stats": first, "top talkers": second}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &refreshStub{errs: tc.errs}
+			task := ViewRefreshTask(store, time.Minute)
+			err := task.Run(context.Background())
+			if len(store.calls) != 7 {
+				t.Fatalf("refreshed %d views, want 7", len(store.calls))
+			}
+			if len(tc.errs) == 0 && err != nil {
+				t.Fatal(err)
+			}
+			for name, cause := range tc.errs {
+				if !errors.Is(err, cause) {
+					t.Errorf("missing cause %v in %v", cause, err)
+				}
+				if err == nil || !strings.Contains(err.Error(), name) {
+					t.Errorf("missing view name %q in %v", name, err)
+				}
+			}
+		})
+	}
+}
+
+func TestViewRefreshTaskCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := ViewRefreshTask(&refreshStub{}, time.Minute).Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want cancellation", err)
+	}
+}
+
+type taskLog chan string
+
+func (w taskLog) Write(p []byte) (int, error) {
+	line := string(p)
+	if strings.Contains(line, "complete") || strings.Contains(line, "failed:") {
+		w <- line
+	}
+	return len(p), nil
+}
+
+func TestSchedulerFailureIsNotComplete(t *testing.T) {
+	lines := make(taskLog, 1)
+	previous := log.Writer()
+	log.SetOutput(lines)
+	defer log.SetOutput(previous)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	New([]Task{{Name: "fails", Interval: time.Millisecond, Run: func(context.Context) error {
+		cancel()
+		return errors.New("refresh unavailable")
+	}}}).Start(ctx)
+	select {
+	case line := <-lines:
+		if strings.Contains(line, "complete") || !strings.Contains(line, "refresh unavailable") {
+			t.Fatalf("incorrect failure status: %s", line)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not report task outcome")
+	}
+}


### PR DESCRIPTION
## What this PR does

Closes #110. Return named, joined errors when materialized-view refreshes fail, while continuing to attempt the remaining views. The scheduler logs `failed` for unsuccessful tasks and reserves `complete` for successful runs. Cancellation remains visible through `errors.Is`.

The existing scheduler tests assumed worker goroutines would run within 30–50 ms of real time; one failed under the Pi's CPU limit. Run those tests with Go's standard `testing/synctest` clock so they exercise the same scheduling/cancellation behavior without depending on host load.

## Type of change

- [x] Bug fix
- [x] Tests

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Regressions cover successful refresh, multiple failures, continued refresh attempts, cancellation and scheduler outcome logging
- [x] No database schema, API shape or dependency change
- [x] I have read `CONTRIBUTING.md`

## Testing notes

The regression tests fail against the original behavior: refresh errors return nil and a failed task logs `complete`. Native ARM64 build and complete regular test suite passed on Pi 5. Relevant Windows race checks passed; Pi race tests cannot start because ThreadSanitizer rejects the host's virtual-memory layout.

This patch corrects task outcome reporting. Per-view last-success timestamps and public freshness metadata are separate follow-ups.

AI tools assisted this implementation. The contributor reviewed and approved the diff and test evidence before submission.

A [combined development preview](https://canadaverse.org/beacon-dev/) includes PRs #111, #112, #113 and #115. Its [source and build details](https://canadaverse.org/beacon-dev/source.html) identify the exact build. MQTT keepalive reconnects are tracked separately in #116.
