### PR TITLE
fix(ingest): isolate MQTT client IDs across workers

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -37,9 +37,9 @@ package ingest
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -234,9 +234,11 @@ func New(cfg Config, db DB, h *hub.Hub, keys ChannelKeyStore, scopes ScopeStore)
 //
 // Intended usage: go worker.Start(ctx)
 func (w *Worker) Start(ctx context.Context) {
+	// Isolate workers across deployments; Paho reuses this ID on reconnect.
+	// Keep it alphanumeric and within MQTT 3.1's 23-character client ID limit.
 	opts := mqtt.NewClientOptions().
 		AddBroker(w.cfg.URL).
-		SetClientID(fmt.Sprintf("beacon-%s", w.cfg.BrokerName)).
+		SetClientID(rand.Text()[:23]).
 		SetUsername(w.cfg.Username).
 		SetPassword(w.cfg.Password).
 		SetAutoReconnect(true).

--- a/internal/ingest/mqtt_test.go
+++ b/internal/ingest/mqtt_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingest
+
+import (
+	"context"
+	"net"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.mqtt.golang/packets"
+)
+
+type mqttConnection struct {
+	id   string
+	conn net.Conn
+}
+
+// A local protocol fixture observes the actual CONNECT packets sent by Start.
+// It neither publishes nor connects to a real broker.
+func mqttTestBroker(t *testing.T) (string, <-chan mqttConnection) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connected := make(chan mqttConnection, 4)
+	var clients sync.WaitGroup
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			clients.Add(1)
+			go func() {
+				defer clients.Done()
+				defer conn.Close()
+				_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+				first, err := packets.ReadPacket(conn)
+				if err != nil {
+					return
+				}
+				connect, ok := first.(*packets.ConnectPacket)
+				if !ok {
+					return
+				}
+				if err := packets.NewControlPacket(packets.Connack).Write(conn); err != nil {
+					return
+				}
+				announced := false
+				for {
+					packet, err := packets.ReadPacket(conn)
+					if err != nil {
+						return
+					}
+					switch packet := packet.(type) {
+					case *packets.SubscribePacket:
+						ack := packets.NewControlPacket(packets.Suback).(*packets.SubackPacket)
+						ack.MessageID = packet.MessageID
+						ack.ReturnCodes = []byte{1}
+						if err := ack.Write(conn); err != nil {
+							return
+						}
+						if !announced {
+							connected <- mqttConnection{connect.ClientIdentifier, conn}
+							announced = true
+						}
+					case *packets.PingreqPacket:
+						if err := packets.NewControlPacket(packets.Pingresp).Write(conn); err != nil {
+							return
+						}
+					case *packets.DisconnectPacket:
+						return
+					}
+				}
+			}()
+		}
+	}()
+	t.Cleanup(func() { _ = listener.Close(); <-stopped; clients.Wait() })
+	return "tcp://" + listener.Addr().String(), connected
+}
+
+func startMQTTTestWorker(t *testing.T, address string) {
+	t.Helper()
+	w, _ := newTestWorker()
+	w.cfg.URL = address
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); w.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Error("worker did not stop")
+		}
+	})
+}
+
+func awaitMQTTConnection(t *testing.T, connected <-chan mqttConnection) mqttConnection {
+	t.Helper()
+	select {
+	case c := <-connected:
+		return c
+	case <-time.After(5 * time.Second):
+		t.Fatal("MQTT CONNECT not received")
+		return mqttConnection{}
+	}
+}
+
+func TestWorkersUseDistinctMQTTClientIDs(t *testing.T) {
+	address, connected := mqttTestBroker(t)
+	startMQTTTestWorker(t, address)
+	first := awaitMQTTConnection(t, connected)
+	startMQTTTestWorker(t, address)
+	second := awaitMQTTConnection(t, connected)
+	if first.id == "" || second.id == "" || first.id == second.id {
+		t.Fatalf("workers with the same broker name must use distinct client IDs: %q and %q", first.id, second.id)
+	}
+	valid := regexp.MustCompile(`^[A-Za-z0-9]{1,23}$`)
+	if !valid.MatchString(first.id) || !valid.MatchString(second.id) {
+		t.Fatal("client ID must be 1..23 alphanumeric characters")
+	}
+}
+
+func TestReconnectKeepsMQTTClientID(t *testing.T) {
+	address, connected := mqttTestBroker(t)
+	startMQTTTestWorker(t, address)
+	first := awaitMQTTConnection(t, connected)
+	_ = first.conn.Close()
+	second := awaitMQTTConnection(t, connected)
+	if first.id != second.id {
+		t.Fatalf("reconnect changed client ID: %q to %q", first.id, second.id)
+	}
+}


### PR DESCRIPTION
## What this PR does

Related to #116. Workers currently derive their MQTT client ID only from the broker name, so separate Beacon deployments using the same broker configuration send the same ID. Give each worker start a random 23-character alphanumeric ID using `crypto/rand.Text`. Paho keeps that ID for automatic reconnects.

This isolates concurrent subscribers without changing message ordering, subscriptions, acknowledgements, or ingestion concurrency. It adds no dependency or configuration setting.

## Type of change

- [x] Bug fix
- [x] Tests

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Local protocol regression and reconnect tests pass
- [x] No DB, API, generated-code or dependency changes
- [x] I have read `CONTRIBUTING.md`

## Testing notes

A local MQTT fixture reads the real CONNECT packets emitted by two workers with the same broker name. It fails on the old `beacon-test` IDs, passes with distinct IDs, and verifies that a forced reconnect keeps the worker's ID. The two tests passed ten repetitions. The full suite and the ingest race test pass on Windows; the full build, vet, formatting and regular suite also pass natively on Pi 5 with Go 1.26.6.

The counting-only probe received 2,411 messages from both development brokers over three minutes with no disconnects. Callback timing on the original application showed receive freezes with no active callback; a longer diagnostic run also captured occasional slow callbacks. Those are separate observations and this change does not claim to fix every ingestion stall.

The [development preview](https://canadaverse.org/beacon-dev/) runs this candidate on upstream `dev` after #111, #112, #113 and #115 were merged. Its [source page](https://canadaverse.org/beacon-dev/source.html) identifies the exact build.

The original application logged 22 ping-response disconnects in a retained 15-minute window. The candidate then passed a ten-minute live Pi soak (14:28:58–14:38:58 UTC, September 6): zero disconnects, zero API 500 log entries, zero restarts, and 1,585 new retained observations across both brokers (1,293 / 292). Packet-list requests continued to succeed throughout. The ID regression and before/after behavior support this fix; they are not a production-scale or long-duration delivery guarantee, and no broker administration logs were available to identify an external colliding connection.

AI tools assisted implementation and validation under the contributor's standing approval for this effort.
