### PR TITLE
fix(db): paginate complete trace tag groups

### DIFF
--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -1076,9 +1076,9 @@ WITH tags AS (
       AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
       AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
       AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
-      AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
       AND ($7::text = '' OR p.parsed_payload->>'type' = $7)
     GROUP BY p.trace_tag
+    HAVING ($5::timestamptz IS NULL OR MAX(p.last_heard_at) < $5)
     ORDER BY MAX(p.last_heard_at) DESC
     LIMIT $6
 )

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -3123,9 +3123,9 @@ WITH tags AS (
       AND ($2::text = '' OR p.scope_id = (SELECT id FROM transport_scopes WHERE name = $2))
       AND ($3::timestamptz IS NULL OR p.first_heard_at >= $3)
       AND ($4::timestamptz IS NULL OR p.first_heard_at <= $4)
-      AND ($5::timestamptz IS NULL OR p.last_heard_at < $5)
       AND ($7::text = '' OR p.parsed_payload->>'type' = $7)
     GROUP BY p.trace_tag
+    HAVING ($5::timestamptz IS NULL OR MAX(p.last_heard_at) < $5)
     ORDER BY MAX(p.last_heard_at) DESC
     LIMIT $6
 )

--- a/db/trace_pagination_integration_test.go
+++ b/db/trace_pagination_integration_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package db
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
+	"github.com/MeshCore-Beacon/beacon-server/internal/api"
+	"github.com/jackc/pgx/v5"
+)
+
+// Trace tags, not individual packets, are the entities being paginated. All
+// fixture writes use temporary tables and are rolled back on exit.
+func TestTraceTagPaginationPostgres(t *testing.T) {
+	dsn := os.Getenv("BEACON_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set BEACON_TEST_POSTGRES_DSN for the PostgreSQL regression test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(context.Background())
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(context.Background())
+	for _, table := range []string{"packets", "trace_iatas", "transport_scopes"} {
+		if _, err := tx.Exec(ctx, "CREATE TEMP TABLE "+table+" (LIKE public."+table+" INCLUDING ALL) ON COMMIT DROP"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err = tx.Exec(ctx, `
+INSERT INTO transport_scopes (id,name,transport_key,key_fingerprint) VALUES
+ (1,'scope-one',decode(repeat('01',16),'hex'),decode(repeat('01',8),'hex')),
+ (2,'scope-two',decode(repeat('02',16),'hex'),decode(repeat('02',8),'hex'));
+INSERT INTO packets (packet_hash,payload_type,payload_version,route_type,raw_payload,raw_header,trace_tag,scope_id,first_heard_at,last_heard_at,parsed_payload)
+SELECT decode(lpad(to_hex(i),64,'0'),'hex'),9,0,1,'\x00','\x00',decode(tag,'hex'),scope,
+ '2026-01-01'::timestamptz+first*interval '1 second','2026-01-01'::timestamptz+last*interval '1 second',payload::jsonb
+FROM (VALUES
+ (1,'aaaaaaaa',1,1,40,'{"type":"TRACE","pathHashes":["aa"],"snrValues":[1]}'),
+ (2,'aaaaaaaa',1,2,10,'{"type":"TRACE","pathHashes":["aa","bb"],"snrValues":[1,2]}'),
+ (3,'aaaaaaaa',2,3,25,'{"type":"PING","pathHashes":["aa","bb","cc"],"snrValues":[1,2,3]}'),
+ (4,'bbbbbbbb',1,4,30,'{"type":"TRACE","pathHashes":["bb","11","22","33"],"snrValues":[2,3,4,5]}'),
+ (5,'bbbbbbbb',2,5,5,'{"type":"PING","pathHashes":["bb"],"snrValues":[2]}'),
+ (6,'cccccccc',1,6,20,'{"type":"TRACE","pathHashes":["cc"],"snrValues":[3]}'),
+ (7,'dddddddd',2,7,15,'{"type":"PING","pathHashes":["dd"],"snrValues":[4]}'),
+ (8,NULL,1,8,50,'{"type":"TRACE","pathHashes":[],"snrValues":[]}')
+) v(i,tag,scope,first,last,payload);
+INSERT INTO trace_iatas (trace_tag,iata) VALUES
+ ('\xaaaaaaaa','YYZ'),('\xaaaaaaaa','YVR'),('\xbbbbbbbb','YYZ'),('\xcccccccc','YVR');`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &Store{q: sqlc.New(tx)}
+	anchor := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	at := func(seconds int) time.Time {
+		if seconds == 0 {
+			return time.Time{}
+		}
+		return anchor.Add(time.Duration(seconds) * time.Second)
+	}
+	paths := map[string][]string{"a": {"aa", "bb", "cc"}, "b": {"bb", "11", "22", "33"}, "c": {"cc"}, "d": {"dd"}}
+	snrs := map[string][]float32{"a": {1, 2, 3}, "b": {2, 3, 4, 5}, "c": {3}, "d": {4}}
+	summary := func(tag string, first, last int, count, iatas int64, kind string) api.TraceTagSummary {
+		return api.TraceTagSummary{TraceTag: strings.Repeat(tag, 8), FirstHeardAt: at(first).UnixMilli(), LastHeardAt: at(last).UnixMilli(), PacketCount: count, IATACount: iatas, TraceType: kind, PathHashes: paths[tag], SNRValues: snrs[tag]}
+	}
+	a, b, c, d := summary("a", 1, 40, 3, 2, "TRACE"), summary("b", 4, 30, 2, 1, "TRACE"), summary("c", 6, 20, 1, 1, "TRACE"), summary("d", 7, 15, 1, 0, "PING")
+	for _, tc := range []struct {
+		name                 string
+		iatas                []string
+		scope, kind          string
+		since, until, cursor int
+		want                 []api.TraceTagSummary
+	}{
+		{"first page", nil, "", "", 0, 0, 0, []api.TraceTagSummary{a, b, c, d}},
+		{"cursor at newest group", nil, "", "", 0, 0, 40, []api.TraceTagSummary{b, c, d}},
+		{"cursor between packet times", nil, "", "", 0, 0, 30, []api.TraceTagSummary{c, d}},
+		{"end of groups", nil, "", "", 0, 0, 15, []api.TraceTagSummary{}},
+		{"region", []string{"YYZ"}, "", "", 0, 0, 35, []api.TraceTagSummary{b}},
+		{"multiple regions", []string{"YYZ", "YVR", "YYZ"}, "", "", 0, 0, 35, []api.TraceTagSummary{b, c}},
+		{"unknown region", []string{"ZZZ"}, "", "", 0, 0, 0, []api.TraceTagSummary{}},
+		{"scope", nil, "scope-one", "", 0, 0, 30, []api.TraceTagSummary{c}},
+		{"scope defines group", nil, "scope-two", "", 0, 0, 20, []api.TraceTagSummary{d, summary("b", 5, 5, 1, 1, "PING")}},
+		{"type", nil, "", "TRACE", 0, 0, 35, []api.TraceTagSummary{summary("b", 4, 30, 1, 1, "TRACE"), c}},
+		{"type defines group", nil, "", "PING", 0, 0, 30, []api.TraceTagSummary{summary("a", 3, 25, 1, 2, "PING"), d, summary("b", 5, 5, 1, 1, "PING")}},
+		{"time window defines group", nil, "", "", 3, 6, 26, []api.TraceTagSummary{summary("a", 3, 25, 1, 2, "PING"), c}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := store.ListTraceTags(ctx, tc.iatas, tc.scope, tc.kind, at(tc.since), at(tc.until), at(tc.cursor), 20)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("trace summaries differ: got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+	// Reassemble pages using the same epoch-millisecond cursor exposed by the API.
+	reference := map[string]api.TraceTagSummary{a.TraceTag: a, b.TraceTag: b, c.TraceTag: c, d.TraceTag: d}
+	seen := map[string]bool{}
+	var cursor time.Time
+	total := 0
+	for page := 0; page < 10; page++ {
+		rows, err := store.ListTraceTags(ctx, nil, "", "", time.Time{}, time.Time{}, cursor, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			total++
+			if seen[row.TraceTag] {
+				t.Errorf("pagination repeated trace tag %s", row.TraceTag)
+			}
+			seen[row.TraceTag] = true
+			if !reflect.DeepEqual(row, reference[row.TraceTag]) {
+				t.Errorf("pagination changed summary for %s", row.TraceTag)
+			}
+		}
+		cursor = time.UnixMilli(rows[len(rows)-1].LastHeardAt)
+	}
+	t.Logf("two-row pages returned %d summaries for %d distinct trace tags", total, len(seen))
+	if total != 4 || len(seen) != 4 {
+		t.Errorf("expected exactly four complete trace summaries")
+	}
+}


### PR DESCRIPTION
## What this PR does

Closes #123. The trace-list cursor filters individual packets before grouping them by trace tag. A tag returned on an earlier page can therefore appear again with an older timestamp and a smaller packet count.

Apply the cursor to each filtered group's maximum `last_heard_at` in `HAVING`. Existing region, scope, type and time-window filters still define the group; its complete count, timestamps and best-payload selection are preserved. No schema or API contract changes.

## Type of change

- [x] Bug fix
- [x] Tests

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] sqlc regenerated with v1.31.1
- [x] No schema, API handler/type or dependency changes
- [x] I have read `CONTRIBUTING.md`

## Testing notes

The PostgreSQL regression uses temporary tables in a rolled-back transaction and calls the real Store/SQL path. Interleaved packet timestamps make four trace tags produce seven summaries across two-row pages on the original query, including three repeats with altered summaries. The candidate returns exactly four complete summaries. Both outcomes were reproduced in five native Pi 5 runs.

Twelve cases check initial/cursor/end pages, region and duplicate-region filters, unknown regions, scopes, types and inclusive time windows. Cases where scope/type/time filtering changes a group's maximum verify that the cursor uses that filtered maximum. Returned times, counts, IATA counts, type, longest path and SNR values are reconciled.

Full Go checks pass locally and natively on the Pi, including the combined preview source. Live seven-row pages reconcile 45 global traces and 36 regional traces without repeats or changed summaries; TRACE and PING lists also pass. Ordinary API/burst smoke, fresh MQTT ingestion, public source hashes and the populated Traces view pass at the [preview](https://canadaverse.org/beacon-dev/?tab=Traces). Exact combined source: `031fd5659ca038dacd0dc8ceba681fd66fd8564b`, linked from [Source & changes](https://canadaverse.org/beacon-dev/source.html).

The existing timestamp-only cursor still has no tie breaker and is represented in milliseconds. Traversal across equal timestamps or concurrent data changes is not made snapshot-complete by this fix; extending that contract is separate work.

AI tools assisted implementation and validation under the contributor's standing approval for this effort.
