### PR TITLE
fix: include companions in packet endpoint hash matching

### DIFF
--- a/db/endpoint_matching_integration_test.go
+++ b/db/endpoint_matching_integration_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	sqlc "github.com/MeshCore-Beacon/beacon-server/db/sqlc"
+	"github.com/MeshCore-Beacon/beacon-server/internal/api"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type endpointMatchQueries struct {
+	sqlc.DBTX
+	calls int
+	query string
+}
+
+func (q *endpointMatchQueries) Query(ctx context.Context, query string, args ...any) (pgx.Rows, error) {
+	q.calls++
+	q.query = query
+	return q.DBTX.Query(ctx, query, args...)
+}
+
+func TestPacketEndpointRolesPostgres(t *testing.T) {
+	dsn := os.Getenv("BEACON_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set BEACON_TEST_POSTGRES_DSN for the PostgreSQL regression test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(context.Background())
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(context.Background())
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := tx.Exec(ctx, sql, args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, table := range []string{"packets", "packet_observations", "observers", "transport_scopes", "channel_messages", "nodes", "node_short_ids"} {
+		exec("CREATE TEMP TABLE " + table + " (LIKE public." + table + " INCLUDING ALL) ON COMMIT DROP")
+	}
+	id := func(i int) uuid.UUID { return uuid.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)) }
+	exec(`INSERT INTO nodes(id,public_key,name,node_type)
+SELECT ('00000000-0000-0000-0000-'||lpad(i::text,12,'0'))::uuid,
+ decode(prefix||repeat('00',28),'hex'),name,role
+FROM (VALUES (1,'aa000001','Companion',1),(2,'aa000002','Repeater',2),
+ (3,'ee000003','Room',3),(4,'aa000004','Sensor',4),(5,'aa000005','Unknown role',0),
+ (6,'bb000006','Companion only',1),(7,'aa000007','Other region',1),
+ (8,'cc000008','Relay',2),(9,'dd000009',NULL,1),(10,'aa000010','No membership',1)) v(i,prefix,name,role);
+INSERT INTO node_short_ids(node_id,iata,prefix_4)
+SELECT id,CASE WHEN name='Other region' THEN 'YYZ' ELSE 'YVR' END,substring(public_key from 1 for 4)
+FROM nodes WHERE name IS DISTINCT FROM 'No membership';`)
+	exec("INSERT INTO observers(id,public_key) VALUES ($1,'\\x01'),($2,'\\x02')", id(101), id(102))
+	queries := &endpointMatchQueries{DBTX: tx}
+	store := &Store{q: sqlc.New(queries)}
+	check := func(hop *api.ResolvedHop, confidence string, members ...int) {
+		t.Helper()
+		if hop == nil || hop.Confidence != confidence || len(hop.Nodes) != len(members) {
+			t.Errorf("endpoint candidate roles incorrect: confidence=%s, want %s with %d nodes", func() string {
+				if hop == nil {
+					return "nil"
+				}
+				return hop.Confidence
+			}(), confidence, len(members))
+			return
+		}
+		want := make(map[uuid.UUID]bool)
+		for _, member := range members {
+			want[id(member)] = true
+		}
+		for _, node := range hop.Nodes {
+			if !want[node.ID] {
+				t.Errorf("unexpected endpoint node %s", node.ID)
+			}
+			delete(want, node.ID)
+		}
+		if len(want) != 0 {
+			t.Error("endpoint candidate missing")
+		}
+	}
+	for i, kind := range []int{0, 1, 2, 8} {
+		// These encrypted envelopes carry one-byte destination/source prefixes.
+		hash := []byte{byte(i + 1)}
+		payload := append([]byte{0xbb, 0xaa, 0, 0}, make([]byte, 16)...)
+		exec(`INSERT INTO packets(packet_hash,payload_type,payload_version,route_type,raw_payload,raw_header,first_heard_at,last_heard_at)
+VALUES ($1,$2,0,1,$3,$4,NOW(),NOW())`, hash, kind, payload, []byte{byte(kind<<2 | 1)})
+		exec(`INSERT INTO packet_observations(id,packet_hash,observer_id,iata,heard_at,path_length_byte,hash_size,hop_count,path_bytes,source_broker)
+VALUES ($1,$2,$3,'YVR',NOW(),1,1,1,'\xcc','fixture')`, i+1, hash, id(101))
+		packet, err := store.GetPacket(ctx, hash)
+		if err != nil || len(packet.Observations) != 1 {
+			t.Fatalf("packet detail: %v", err)
+		}
+		observation := packet.Observations[0]
+		check(observation.ResolvedSource, "ambiguous", 1, 2, 4, 5)
+		check(observation.ResolvedDestination, "high", 6)
+		if len(observation.ResolvedPath) != 1 {
+			t.Fatal("relay path missing")
+		}
+		check(&observation.ResolvedPath[0], "high", 8)
+	}
+	exec(`INSERT INTO packet_observations(id,packet_hash,observer_id,iata,heard_at,path_length_byte,hash_size,hop_count,source_broker)
+VALUES (10,'\x01',$1,'YYZ',NOW()+interval '1 second',0,1,0,'fixture')`, id(102))
+	packet, err := store.GetPacket(ctx, []byte{1})
+	if err != nil || len(packet.Observations) != 2 {
+		t.Fatalf("regional observations: %v", err)
+	}
+	check(packet.Observations[1].ResolvedSource, "high", 7)
+	check(packet.Observations[1].ResolvedDestination, "none")
+	// Intermediate relay matching keeps its existing infrastructure-only boundary.
+	for width := 1; width <= 4; width++ {
+		hash := []byte{0xaa, 0, 0, 2}[:width]
+		resolved, err := store.ResolvePathHashes(ctx, "YVR", [][]byte{hash})
+		if err != nil {
+			t.Fatal(err)
+		}
+		hops := api.BuildResolvedPath([][]byte{hash}, resolved)
+		check(&hops[0], "high", 2)
+	}
+	t.Log("endpoint roles and unchanged relay matching checked across four payload types")
+	for _, hashes := range [][][]byte{nil, {}, {{}}, {{0xaa, 0xbb}}, {{0xaa}, {0xbb, 0xcc}}} {
+		queries.calls = 0
+		got, err := store.ResolveEndpointHashes(ctx, "YVR", hashes)
+		if err != nil || len(got) != 0 || queries.calls != 0 {
+			t.Fatal("invalid endpoint width reached the database")
+		}
+	}
+	queries.calls = 0
+	resolved, err := store.ResolveEndpointHashes(ctx, "YVR", [][]byte{{0xee}, {0xdd}, {0xff}, {0xbb}, {0xbb}})
+	if err != nil || queries.calls != 1 {
+		t.Fatalf("batched endpoint query: %v, calls=%d", err, queries.calls)
+	}
+	hops := api.BuildResolvedPath([][]byte{{0xee}, {0xdd}, {0xff}, {0xbb}}, resolved)
+	check(&hops[0], "high", 3)
+	check(&hops[1], "high", 9)
+	if hops[1].Nodes[0].Name != nil {
+		t.Error("unnamed node acquired a name")
+	}
+	check(&hops[2], "none")
+	check(&hops[3], "high", 6)
+	missing, err := store.ResolveEndpointHashes(ctx, "ZZZ", [][]byte{{0xaa}})
+	if err != nil || len(missing) != 0 {
+		t.Fatal("endpoint escaped its observation region")
+	}
+
+	// A large nonmatching population must not turn a short-hash lookup into a full scan.
+	exec(`INSERT INTO nodes(id,public_key,node_type)
+SELECT ('00000000-0000-0000-0000-'||lpad(i::text,12,'0'))::uuid,
+ decode(lpad(to_hex(i),8,'0')||repeat('00',28),'hex'),1 FROM generate_series(10000,29999) i;
+INSERT INTO node_short_ids(node_id,iata,prefix_4)
+SELECT id,'YVR',substring(public_key from 1 for 4) FROM nodes WHERE substring(public_key from 1 for 1)='\x00';
+ANALYZE nodes;
+ANALYZE node_short_ids;`)
+	if _, err := store.ResolveEndpointHashes(ctx, "YVR", [][]byte{{0xaa}}); err != nil {
+		t.Fatal(err)
+	}
+	exec("PREPARE endpoint_role_plan AS " + queries.query)
+	defer tx.Exec(context.Background(), "DEALLOCATE endpoint_role_plan")
+	for _, mode := range []string{"force_custom_plan", "force_generic_plan"} {
+		exec("SET LOCAL plan_cache_mode=" + mode)
+		var raw []byte
+		if err := tx.QueryRow(ctx, `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE endpoint_role_plan('YVR',ARRAY['\xaa'::bytea])`).Scan(&raw); err != nil {
+			t.Fatal(err)
+		}
+		var report []struct {
+			Plan         map[string]any
+			Milliseconds float64 `json:"Execution Time"`
+		}
+		if err := json.Unmarshal(raw, &report); err != nil {
+			t.Fatal(err)
+		}
+		var examined, nodeRows float64
+		indexed := false
+		var walk func(map[string]any)
+		walk = func(plan map[string]any) {
+			if cond, ok := plan["Index Cond"].(string); ok && strings.Contains(cond, "prefix_1") && strings.Contains(cond, "iata") {
+				indexed = true
+			}
+			if plan["Relation Name"] == "node_short_ids" {
+				rows, _ := plan["Actual Rows"].(float64)
+				removed, _ := plan["Rows Removed by Filter"].(float64)
+				loops, _ := plan["Actual Loops"].(float64)
+				examined += (rows + removed) * loops
+			}
+			if plan["Relation Name"] == "nodes" {
+				rows, _ := plan["Actual Rows"].(float64)
+				removed, _ := plan["Rows Removed by Filter"].(float64)
+				loops, _ := plan["Actual Loops"].(float64)
+				nodeRows += (rows + removed) * loops
+			}
+			if children, ok := plan["Plans"].([]any); ok {
+				for _, child := range children {
+					walk(child.(map[string]any))
+				}
+			}
+		}
+		walk(report[0].Plan)
+		if !indexed || examined > 10 || nodeRows > 10 {
+			t.Errorf("%s endpoint lookup scanned %.0f short IDs and %.0f nodes, indexed=%v", mode, examined, nodeRows, indexed)
+		}
+		t.Logf("%s: %.0f short-ID rows and %.0f node rows examined in %.3f ms", mode, examined, nodeRows, report[0].Milliseconds)
+	}
+}

--- a/db/packets.go
+++ b/db/packets.go
@@ -476,7 +476,7 @@ func (s *Store) GetPacket(ctx context.Context, packetHash []byte) (*api.Packet, 
 			hop := api.ResolveExactNode(resolvedAdvertSource)
 			obs.ResolvedSource = &hop
 		} else if len(sourceHashByte) == 1 {
-			if r, err := s.ResolvePathHashes(ctx, v.Iata, [][]byte{sourceHashByte}); err != nil {
+			if r, err := s.ResolveEndpointHashes(ctx, v.Iata, [][]byte{sourceHashByte}); err != nil {
 				log.Printf("store: source resolution failed for observation %d: %v", v.ID, err)
 			} else {
 				hop := api.BuildResolvedPath([][]byte{sourceHashByte}, r)[0]
@@ -484,7 +484,7 @@ func (s *Store) GetPacket(ctx context.Context, packetHash []byte) (*api.Packet, 
 			}
 		}
 		if len(destHashByte) == 1 {
-			if r, err := s.ResolvePathHashes(ctx, v.Iata, [][]byte{destHashByte}); err != nil {
+			if r, err := s.ResolveEndpointHashes(ctx, v.Iata, [][]byte{destHashByte}); err != nil {
 				log.Printf("store: destination resolution failed for observation %d: %v", v.ID, err)
 			} else {
 				hop := api.BuildResolvedPath([][]byte{destHashByte}, r)[0]

--- a/db/queries/queries.sql
+++ b/db/queries/queries.sql
@@ -1204,6 +1204,21 @@ WHERE ns.iata = $1
   AND n.node_type IN (2, 3)
   AND ns.prefix_1 = ANY($2::bytea[]);
 
+-- name: ResolveEndpointHashes :many
+-- Logical endpoints can be any advertised role, unlike intermediate relay hops.
+-- Endpoint hashes are always one byte; use the existing (iata, prefix_1) index.
+-- LIMIT 1 keeps generic plans on a node PK lookup per candidate instead of
+-- flattening the join into a scan of all nodes. The PK already guarantees one row.
+SELECT ns.prefix_1 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+CROSS JOIN LATERAL (
+  SELECT id, name, latitude, longitude, public_key
+  FROM nodes WHERE id = ns.node_id
+  LIMIT 1
+) n
+WHERE ns.iata = $1
+  AND ns.prefix_1 = ANY($2::bytea[]);
+
 -- name: ResolvePathHashesP2 :many
 SELECT ns.prefix_4 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
 FROM node_short_ids ns

--- a/db/sqlc/mock/querier.go
+++ b/db/sqlc/mock/querier.go
@@ -1152,6 +1152,21 @@ func (mr *MockQuerierMockRecorder) RefreshTopTalkers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTopTalkers", reflect.TypeOf((*MockQuerier)(nil).RefreshTopTalkers), ctx)
 }
 
+// ResolveEndpointHashes mocks base method.
+func (m *MockQuerier) ResolveEndpointHashes(ctx context.Context, arg db.ResolveEndpointHashesParams) ([]db.ResolveEndpointHashesRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveEndpointHashes", ctx, arg)
+	ret0, _ := ret[0].([]db.ResolveEndpointHashesRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveEndpointHashes indicates an expected call of ResolveEndpointHashes.
+func (mr *MockQuerierMockRecorder) ResolveEndpointHashes(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveEndpointHashes", reflect.TypeOf((*MockQuerier)(nil).ResolveEndpointHashes), ctx, arg)
+}
+
 // ResolvePathHashesP1 mocks base method.
 func (m *MockQuerier) ResolvePathHashesP1(ctx context.Context, arg db.ResolvePathHashesP1Params) ([]db.ResolvePathHashesP1Row, error) {
 	m.ctrl.T.Helper()

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -187,6 +187,11 @@ type Querier interface {
 	RefreshTopNodes(ctx context.Context) error
 	RefreshTopObservers(ctx context.Context) error
 	RefreshTopTalkers(ctx context.Context) error
+	// Logical endpoints can be any advertised role, unlike intermediate relay hops.
+	// Endpoint hashes are always one byte; use the existing (iata, prefix_1) index.
+	// LIMIT 1 keeps generic plans on a node PK lookup per candidate instead of
+	// flattening the join into a scan of all nodes. The PK already guarantees one row.
+	ResolveEndpointHashes(ctx context.Context, arg ResolveEndpointHashesParams) ([]ResolveEndpointHashesRow, error)
 	// ============================================================
 	// HELPERS
 	// ============================================================

--- a/db/sqlc/queries.sql.go
+++ b/db/sqlc/queries.sql.go
@@ -3389,6 +3389,63 @@ func (q *Queries) RefreshTopTalkers(ctx context.Context) error {
 	return err
 }
 
+const resolveEndpointHashes = `-- name: ResolveEndpointHashes :many
+SELECT ns.prefix_1 AS hash, n.id AS node_id, n.name, n.latitude, n.longitude, n.public_key
+FROM node_short_ids ns
+CROSS JOIN LATERAL (
+  SELECT id, name, latitude, longitude, public_key
+  FROM nodes WHERE id = ns.node_id
+  LIMIT 1
+) n
+WHERE ns.iata = $1
+  AND ns.prefix_1 = ANY($2::bytea[])
+`
+
+type ResolveEndpointHashesParams struct {
+	Iata    string   `json:"iata"`
+	Column2 [][]byte `json:"column_2"`
+}
+
+type ResolveEndpointHashesRow struct {
+	Hash      []byte    `json:"hash"`
+	NodeID    uuid.UUID `json:"node_id"`
+	Name      *string   `json:"name"`
+	Latitude  *float64  `json:"latitude"`
+	Longitude *float64  `json:"longitude"`
+	PublicKey []byte    `json:"public_key"`
+}
+
+// Logical endpoints can be any advertised role, unlike intermediate relay hops.
+// Endpoint hashes are always one byte; use the existing (iata, prefix_1) index.
+// LIMIT 1 keeps generic plans on a node PK lookup per candidate instead of
+// flattening the join into a scan of all nodes. The PK already guarantees one row.
+func (q *Queries) ResolveEndpointHashes(ctx context.Context, arg ResolveEndpointHashesParams) ([]ResolveEndpointHashesRow, error) {
+	rows, err := q.db.Query(ctx, resolveEndpointHashes, arg.Iata, arg.Column2)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ResolveEndpointHashesRow{}
+	for rows.Next() {
+		var i ResolveEndpointHashesRow
+		if err := rows.Scan(
+			&i.Hash,
+			&i.NodeID,
+			&i.Name,
+			&i.Latitude,
+			&i.Longitude,
+			&i.PublicKey,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const resolvePathHashesP1 = `-- name: ResolvePathHashesP1 :many
 
 

--- a/db/store.go
+++ b/db/store.go
@@ -83,6 +83,32 @@ func (s *Store) ResolvePathHashes(ctx context.Context, iata string, hashes [][]b
 	return result, nil
 }
 
+// ResolveEndpointHashes matches one-byte packet endpoints across advertised roles.
+// Keep this separate from the infrastructure-only intermediate path resolver.
+func (s *Store) ResolveEndpointHashes(ctx context.Context, iata string, hashes [][]byte) (map[string][]api.ResolvedPathEntry, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	for _, hash := range hashes {
+		if len(hash) != 1 {
+			return nil, nil
+		}
+	}
+	rows, err := s.q.ResolveEndpointHashes(ctx, sqlc.ResolveEndpointHashesParams{Iata: iata, Column2: hashes})
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string][]api.ResolvedPathEntry)
+	for _, row := range rows {
+		key := hex.EncodeToString(row.Hash)
+		result[key] = append(result[key], api.ResolvedPathEntry{
+			NodeID: row.NodeID, Name: row.Name, Latitude: row.Latitude,
+			Longitude: row.Longitude, PublicKey: row.PublicKey,
+		})
+	}
+	return result, nil
+}
+
 // nullableUUID returns nil for a zero UUID, or a pointer to the UUID otherwise.
 func nullableUUID(id uuid.UUID) *uuid.UUID {
 	if id == (uuid.UUID{}) {

--- a/internal/ingest/endpoint_matching_test.go
+++ b/internal/ingest/endpoint_matching_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingest
+
+import (
+	"context"
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/MeshCore-Beacon/beacon-server/internal/api"
+	"github.com/meshcore-go/meshcore-go"
+)
+
+type endpointRoutingDB struct {
+	*stubDB
+	endpoints []string
+	paths     []string
+}
+
+func (s *endpointRoutingDB) ResolveEndpointHashes(_ context.Context, iata string, hashes [][]byte) (map[string][]api.ResolvedPathEntry, error) {
+	for _, hash := range hashes {
+		s.endpoints = append(s.endpoints, iata+":"+hex.EncodeToString(hash))
+	}
+	return nil, nil
+}
+func (s *endpointRoutingDB) ResolvePathHashes(_ context.Context, iata string, hashes [][]byte) (map[string][]api.ResolvedPathEntry, error) {
+	for _, hash := range hashes {
+		s.paths = append(s.paths, iata+":"+hex.EncodeToString(hash))
+	}
+	return nil, nil
+}
+
+func TestHandlePacketSeparatesEndpointAndRelayMatching(t *testing.T) {
+	for _, kind := range []uint8{meshcore.PayloadTypeReq, meshcore.PayloadTypeResponse, meshcore.PayloadTypeTxtMsg, meshcore.PayloadTypePath} {
+		w, base := newTestWorker()
+		db := &endpointRoutingDB{stubDB: base}
+		w.db = db
+		packet := &meshcore.Packet{Header: meshcore.MakeHeader(meshcore.RouteTypeFlood, kind, 0),
+			PathLength: 1, Path: []byte{0xcc}, Payload: append([]byte{0xbb, 0xaa, 0, 0}, make([]byte, 16)...)}
+		w.handlePacket(context.Background(), "YVR", "0102", packetEnvelope(t, packet))
+		if !reflect.DeepEqual(db.endpoints, []string{"YVR:aa", "YVR:bb"}) {
+			t.Errorf("payload %d endpoint dispatch: %v", kind, db.endpoints)
+		}
+		if !reflect.DeepEqual(db.paths, []string{"YVR:cc"}) {
+			t.Errorf("payload %d relay dispatch: %v", kind, db.paths)
+		}
+	}
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -153,6 +153,9 @@ type DB interface {
 	// ResolvePathHashes returns a list of node UUIDs for the given path hash prefixes and IATA.
 	ResolvePathHashes(ctx context.Context, iata string, hashes [][]byte) (map[string][]api.ResolvedPathEntry, error)
 
+	// ResolveEndpointHashes matches one-byte logical endpoints, including companions.
+	ResolveEndpointHashes(ctx context.Context, iata string, hashes [][]byte) (map[string][]api.ResolvedPathEntry, error)
+
 	// UpsertChannel upserts a channel row by (hash, keyFingerprint) and returns its integer ID.
 	// Pass nil keyFingerprint to record a hash-only row when the key is unknown.
 	UpsertChannel(ctx context.Context, channelHash []byte, keyFingerprint []byte, name string, hashtag string) (int, error)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -252,6 +252,10 @@ func (s *stubDB) ResolvePathHashes(_ context.Context, _ string, _ [][]byte) (map
 	return nil, nil
 }
 
+func (s *stubDB) ResolveEndpointHashes(_ context.Context, _ string, _ [][]byte) (map[string][]api.ResolvedPathEntry, error) {
+	return nil, nil
+}
+
 func (s *stubDB) UpsertChannel(_ context.Context, _ []byte, _ []byte, _, _ string) (int, error) {
 	s.upsertChannelCalls++
 	return 0, nil

--- a/internal/ingest/packet.go
+++ b/internal/ingest/packet.go
@@ -850,13 +850,13 @@ func (w *Worker) handlePacket(ctx context.Context, iata, pubkeyHex string, raw [
 			}
 		}
 	} else if len(sourceHashByte) == 1 {
-		if r, err := w.db.ResolvePathHashes(ctx, iata, [][]byte{sourceHashByte}); err == nil {
+		if r, err := w.db.ResolveEndpointHashes(ctx, iata, [][]byte{sourceHashByte}); err == nil {
 			hop := api.BuildResolvedPath([][]byte{sourceHashByte}, r)[0]
 			resolvedSource = &hop
 		}
 	}
 	if len(destHashByte) == 1 {
-		if r, err := w.db.ResolvePathHashes(ctx, iata, [][]byte{destHashByte}); err == nil {
+		if r, err := w.db.ResolveEndpointHashes(ctx, iata, [][]byte{destHashByte}); err == nil {
 			hop := api.BuildResolvedPath([][]byte{destHashByte}, r)[0]
 			resolvedDestination = &hop
 		}


### PR DESCRIPTION
## What this PR does

Closes #129. Short packet endpoint hashes currently use the relay-hop resolver, which filters to repeaters and room servers. A companion-only endpoint stays unresolved, and a repeater can appear to be the sole known match when a companion shares its prefix.

Add a dedicated one-byte endpoint query across advertised node roles and use it for source/destination resolution in ingest and packet detail. Reuse the existing `(iata, prefix_1)` index. Exact ADVERT matching and all intermediate-hop, trace and neighbor matching remain unchanged. Region membership, ambiguous/unknown results and existing stored snapshots are preserved.

The per-candidate node lookup keeps generic prepared plans from flattening the join into a full node scan. Its `LIMIT 1` does not truncate valid candidates: node ID is already a primary key.

## Type of change

- [x] Bug fix
- [x] Tests

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] sqlc v1.31.1 and existing MockGen v0.6.0 output regenerated
- [x] No schema, index, API handler/type or dependency changes
- [x] I have read `CONTRIBUTING.md`

## Testing notes

The original PostgreSQL regression fails on missing companions and falsely unique repeater matches. Five native Pi runs pass for REQUEST, RESPONSE, TEXT_MESSAGE and PATH detail reads, companion/repeater/room/sensor/unknown-role candidates, cross-role collisions, other/missing IATAs, absent names, unknown prefixes, duplicate inputs and unsupported widths. Ingest tests verify that endpoints and relay hops use their separate resolvers. Relay matching remains infrastructure-only for all four supported path widths.

With 20,000 additional nonmatching nodes, custom and generic plans each examine four short-ID rows and four node rows. A plain-join candidate examined 20,010 node rows under a generic plan; the final query avoids that work. The gate asserts indexed work, not elapsed time. These are synthetic measurements, not a production-wide speed claim.

Full Go checks and Windows ingest/DB race checks pass. The prior snapshot PR's fixture has a six-line test-only compatibility update, and the combined source preserves snapshot capture while using the new resolver.

The [combined Pi preview](https://canadaverse.org/beacon-dev/) runs source `e1eca8c16c5e3f42534bf0c4c6a8c73b59c01e2d`, with [corresponding source](https://canadaverse.org/beacon-dev/source.html). Live traffic includes 37 companion candidates, including 12 uniquely matched endpoints. All 100 sampled pre-existing snapshots remained unchanged; ten live-to-history comparisons retained the same named endpoints without mismatches. Eight API groups and a 20-request concurrent burst passed with fresh MQTT observations, both brokers connected, zero restarts and no API or snapshot-encoding errors.

A unique known prefix candidate remains a candidate, not authenticated sender identity. Stored snapshots from earlier resolver versions are not rewritten.

AI tools assisted implementation and validation under the contributor's standing approval for this effort.
