### PR TITLE
fix(api): trust client IP headers only from configured proxies

### DIFF
--- a/cmd/beacon/main.go
+++ b/cmd/beacon/main.go
@@ -272,7 +272,7 @@ func main() {
 	go scheduler.Start(ctx)
 
 	// ── HTTP server ──────────────────────────────────────────────────────────
-	r := router.New(h, reader, []*ingest.Worker{broker1, broker2}, resolved.MaxConnsPerIP, cfg.CORS)
+	r := router.New(h, reader, []*ingest.Worker{broker1, broker2}, resolved.MaxConnsPerIP, cfg.CORS, cfg.Server)
 
 	srv := &http.Server{
 		Addr:    addr,

--- a/cmd/beacon/main.go
+++ b/cmd/beacon/main.go
@@ -88,6 +88,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
 	}
+	if len(cfg.Server.TrustedProxies) == 0 {
+		log.Print("warning: server.trusted_proxies is empty; client IP headers are ignored and proxied clients share a WebSocket connection limit")
+	}
 
 	resolved := config.Resolve(cfg)
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,6 +1,14 @@
 # Beacon configuration file
 # Copy to config.yaml and adjust as needed.
 
+server:
+  # Only these direct proxy peers may set the client IP through X-Real-IP.
+  # The proxy must overwrite that header, not pass through client input.
+  # Leave empty for direct access. Invalid CIDRs prevent startup.
+  # For Docker, list the actual proxy/compose network CIDR (e.g. 172.20.0.0/24).
+  # For a host proxy, use ["127.0.0.1/8", "::1/128"].
+  trusted_proxies: []
+
 iatas:
   YVR:
     name: Vancouver International

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -4,9 +4,20 @@
 server:
   # Only these direct proxy peers may set the client IP through X-Real-IP.
   # The proxy must overwrite that header, not pass through client input.
-  # Leave empty for direct access. Invalid CIDRs prevent startup.
+  # Leave empty for direct access (logs a startup warning). Invalid/empty CIDR
+  # entries prevent startup. A single host needs /32 for IPv4 or /128 for IPv6;
+  # bare IP addresses are not accepted.
   # For Docker, list the actual proxy/compose network CIDR (e.g. 172.20.0.0/24).
-  # For a host proxy, use ["127.0.0.1/8", "::1/128"].
+  # For a local host proxy, use ["127.0.0.1/32", "::1/128"].
+  # Direct-client proxy examples; X-Forwarded-For alone is not used:
+  # Apache 2.4.10+ (mod_headers, in the proxy virtual host):
+  #   RequestHeader set X-Real-IP "expr=%{REMOTE_ADDR}"
+  # nginx (in the proxy location):
+  #   proxy_set_header X-Real-IP $remote_addr;
+  # Caddy (inside the reverse_proxy block):
+  #   header_up X-Real-IP {http.request.remote.host}
+  # With additional proxy hops, first configure their trust at the edge proxy
+  # and pass its validated client address rather than a client-supplied header.
   trusted_proxies: []
 
 iatas:

--- a/internal/api/middleware/trusted_proxy.go
+++ b/internal/api/middleware/trusted_proxy.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package middleware
+
+import (
+	"net/http"
+	"net/netip"
+)
+
+// TrustedProxyIP accepts X-Real-IP only from a configured direct proxy peer.
+// Run it before the access logger and handlers that use RemoteAddr as a key.
+// All other forwarding headers are ignored, as are invalid/ambiguous values.
+func TrustedProxyIP(proxies []netip.Prefix) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			peer, err := netip.ParseAddrPort(r.RemoteAddr)
+			if err == nil {
+				for _, proxy := range proxies {
+					if !proxy.Contains(peer.Addr().Unmap()) {
+						continue
+					}
+					if values := r.Header.Values("X-Real-IP"); len(values) == 1 {
+						if ip, err := netip.ParseAddr(values[0]); err == nil && ip.Zone() == "" {
+							r.RemoteAddr = ip.Unmap().String()
+						}
+					}
+					break
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/middleware/trusted_proxy.go
+++ b/internal/api/middleware/trusted_proxy.go
@@ -28,6 +28,11 @@ func TrustedProxyIP(proxies []netip.Prefix) func(http.Handler) http.Handler {
 					break
 				}
 			}
+			// Downstream client-IP keys must use the resolved RemoteAddr, not
+			// reinterpret forwarding headers (including those from trusted peers).
+			r.Header.Del("True-Client-IP")
+			r.Header.Del("X-Forwarded-For")
+			r.Header.Del("X-Real-IP")
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/internal/api/middleware/trusted_proxy_test.go
+++ b/internal/api/middleware/trusted_proxy_test.go
@@ -42,9 +42,18 @@ func TestTrustedProxyIP(t *testing.T) {
 			// These must never override the selected address, even for trusted peers.
 			r.Header.Set("True-Client-IP", "203.0.113.1")
 			r.Header.Set("X-Forwarded-For", "203.0.113.2")
+			r.Header.Set("X-Request-ID", "keep-me")
 			TrustedProxyIP(tc.proxies)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.RemoteAddr != tc.want {
 					t.Errorf("RemoteAddr = %q, want %q", r.RemoteAddr, tc.want)
+				}
+				for _, header := range []string{"True-Client-IP", "X-Forwarded-For", "X-Real-IP"} {
+					if len(r.Header.Values(header)) != 0 {
+						t.Errorf("downstream middleware can still read %s", header)
+					}
+				}
+				if r.Header.Get("X-Request-ID") != "keep-me" {
+					t.Error("unrelated header was changed")
 				}
 			})).ServeHTTP(httptest.NewRecorder(), r)
 		})

--- a/internal/api/middleware/trusted_proxy_test.go
+++ b/internal/api/middleware/trusted_proxy_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+func TestTrustedProxyIP(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("192.0.2.0/24"), netip.MustParsePrefix("2001:db8:1::/48")}
+	for _, tc := range []struct {
+		name, peer string
+		proxies    []netip.Prefix
+		realIP     []string
+		want       string
+	}{
+		{"empty allowlist", "192.0.2.10:1234", nil, []string{"198.51.100.1"}, "192.0.2.10:1234"},
+		{"untrusted peer", "192.0.3.10:1234", trusted, []string{"198.51.100.1"}, "192.0.3.10:1234"},
+		{"trusted IPv4", "192.0.2.10:1234", trusted, []string{"198.51.100.1"}, "198.51.100.1"},
+		{"trusted IPv6", "[2001:db8:1::10]:1234", trusted, []string{"2001:db8:2::1"}, "2001:db8:2::1"},
+		{"mapped peer", "[::ffff:192.0.2.10]:1234", trusted, []string{"198.51.100.1"}, "198.51.100.1"},
+		{"mapped client", "192.0.2.10:1234", trusted, []string{"::ffff:198.51.100.1"}, "198.51.100.1"},
+		{"missing header", "192.0.2.10:1234", trusted, nil, "192.0.2.10:1234"},
+		{"empty header", "192.0.2.10:1234", trusted, []string{""}, "192.0.2.10:1234"},
+		{"invalid IP", "192.0.2.10:1234", trusted, []string{"not-an-ip"}, "192.0.2.10:1234"},
+		{"IP with port", "192.0.2.10:1234", trusted, []string{"198.51.100.1:8080"}, "192.0.2.10:1234"},
+		{"IP with zone", "192.0.2.10:1234", trusted, []string{"fe80::1%eth0"}, "192.0.2.10:1234"},
+		{"comma list", "192.0.2.10:1234", trusted, []string{"198.51.100.1, 198.51.100.2"}, "192.0.2.10:1234"},
+		{"repeated header", "192.0.2.10:1234", trusted, []string{"198.51.100.1", "198.51.100.2"}, "192.0.2.10:1234"},
+		{"invalid peer", "unknown", trusted, []string{"198.51.100.1"}, "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tc.peer
+			for _, ip := range tc.realIP {
+				r.Header.Add("X-Real-IP", ip)
+			}
+			// These must never override the selected address, even for trusted peers.
+			r.Header.Set("True-Client-IP", "203.0.113.1")
+			r.Header.Set("X-Forwarded-For", "203.0.113.2")
+			TrustedProxyIP(tc.proxies)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.RemoteAddr != tc.want {
+					t.Errorf("RemoteAddr = %q, want %q", r.RemoteAddr, tc.want)
+				}
+			})).ServeHTTP(httptest.NewRecorder(), r)
+		})
+	}
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -41,7 +41,7 @@ import (
 //
 // The private group is stubbed and ready for the auth middleware drop-in
 // described in Future Features → Admin authentication.
-func New(h *hub.Hub, reader api.Reader, workers []*ingest.Worker, maxConnsPerIP int, corsCfg config.CORSConfig) http.Handler {
+func New(h *hub.Hub, reader api.Reader, workers []*ingest.Worker, maxConnsPerIP int, corsCfg config.CORSConfig, serverCfg config.ServerConfig) http.Handler {
 	r := chi.NewRouter()
 
 	// ── CORS ─────────────────────────────────────────────────────────────────
@@ -71,7 +71,7 @@ func New(h *hub.Hub, reader api.Reader, workers []*ingest.Worker, maxConnsPerIP 
 
 	// ── Global middleware ────────────────────────────────────────────────────
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	r.Use(mw.TrustedProxyIP(serverCfg.TrustedProxies))
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.CleanPath)

--- a/internal/api/router/router_test.go
+++ b/internal/api/router/router_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Beacon Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/MeshCore-Beacon/beacon-server/internal/config"
+	"github.com/MeshCore-Beacon/beacon-server/internal/hub"
+)
+
+func TestWebSocketLimitIgnoresUntrustedHeaders(t *testing.T) {
+	checkWebSocketLimit(t, config.ServerConfig{}, "198.51.100.2", http.StatusTooManyRequests)
+}
+
+func TestWebSocketLimitUsesTrustedClientIP(t *testing.T) {
+	cfg := config.ServerConfig{TrustedProxies: []netip.Prefix{
+		netip.MustParsePrefix("127.0.0.1/8"), netip.MustParsePrefix("::1/128"),
+	}}
+	t.Run("different clients", func(t *testing.T) {
+		checkWebSocketLimit(t, cfg, "198.51.100.2", http.StatusSwitchingProtocols)
+	})
+	t.Run("same client", func(t *testing.T) {
+		checkWebSocketLimit(t, cfg, "198.51.100.1", http.StatusTooManyRequests)
+	})
+}
+
+func checkWebSocketLimit(t *testing.T, cfg config.ServerConfig, secondIP string, wantStatus int) {
+	t.Helper()
+	server := httptest.NewServer(New(hub.New(), nil, nil, 1, config.CORSConfig{}, cfg))
+	defer server.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	dial := func(ip string) (*websocket.Conn, *http.Response, error) {
+		return websocket.Dial(ctx, url, &websocket.DialOptions{HTTPHeader: http.Header{
+			"X-Real-Ip": {ip}, "True-Client-Ip": {ip}, "X-Forwarded-For": {ip},
+		}})
+	}
+	first, _, err := dial("198.51.100.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.CloseNow()
+	if _, _, err := first.Read(ctx); err != nil {
+		t.Fatalf("read hello: %v", err)
+	}
+	second, response, err := dial(secondIP)
+	if second != nil {
+		second.CloseNow()
+	}
+	if response == nil || response.StatusCode != wantStatus || (err == nil) != (wantStatus == http.StatusSwitchingProtocols) {
+		t.Fatalf("second connection: response=%v err=%v, want status %d", response, err, wantStatus)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,24 @@ type ServerConfig struct {
 	TrustedProxies []netip.Prefix `yaml:"trusted_proxies"`
 }
 
+func (c *ServerConfig) UnmarshalYAML(node *yaml.Node) error {
+	// Pointers retain null list entries, which yaml would otherwise discard.
+	// Leave them as invalid prefixes for Load's validation below.
+	var raw struct {
+		TrustedProxies []*netip.Prefix `yaml:"trusted_proxies"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	c.TrustedProxies = make([]netip.Prefix, len(raw.TrustedProxies))
+	for i, prefix := range raw.TrustedProxies {
+		if prefix != nil {
+			c.TrustedProxies[i] = *prefix
+		}
+	}
+	return nil
+}
+
 // ResolvedConfig holds all runtime configuration with defaults applied.
 type ResolvedConfig struct {
 	TelemetryResolution  time.Duration
@@ -321,6 +339,11 @@ func Load(path string) (*Config, error) {
 	}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, err
+	}
+	for i, prefix := range cfg.Server.TrustedProxies {
+		if !prefix.IsValid() {
+			return nil, fmt.Errorf("server.trusted_proxies[%d] must be a valid CIDR", i)
+		}
 	}
 	configDir := filepath.Dir(path)
 	for iata, details := range cfg.IATAs {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"time"
@@ -16,6 +17,7 @@ import (
 
 // Config is the top-level structure of the Beacon config file.
 type Config struct {
+	Server      ServerConfig          `yaml:"server"`
 	IATAs       map[string]IATAConfig `yaml:"iatas"`
 	Regions     []RegionConfig        `yaml:"regions"`
 	ChannelKeys ChannelKeysConfig     `yaml:"channel_keys"`
@@ -31,6 +33,13 @@ type Config struct {
 	Presence    PresenceConfig        `yaml:"presence"`
 	Nodes       NodesConfig           `yaml:"nodes"`
 	Observers   ObserversConfig       `yaml:"observers"`
+}
+
+// ServerConfig controls which direct peers may supply the client address.
+type ServerConfig struct {
+	// TrustedProxies accepts IPv4/IPv6 CIDRs; an empty list trusts no proxy.
+	// netip.Prefix validates each CIDR while the configuration is loaded.
+	TrustedProxies []netip.Prefix `yaml:"trusted_proxies"`
 }
 
 // ResolvedConfig holds all runtime configuration with defaults applied.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,8 @@ func TestLoadTrustedProxies(t *testing.T) {
 		{"CIDRs", "server: {trusted_proxies: ['192.0.2.0/24', '2001:db8::/32']}", 2, false},
 		{"bare IP", "server: {trusted_proxies: ['192.0.2.1']}", 0, true},
 		{"invalid CIDR", "server: {trusted_proxies: ['192.0.2.0/99']}", 0, true},
+		{"empty entry", "server: {trusted_proxies: ['', '192.0.2.0/24']}", 0, true},
+		{"null entry", "server: {trusted_proxies: [null, '192.0.2.0/24']}", 0, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "config.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,10 +5,39 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestLoadTrustedProxies(t *testing.T) {
+	for _, tc := range []struct {
+		name, yaml string
+		count      int
+		wantError  bool
+	}{
+		{"omitted", "{}", 0, false},
+		{"empty", "server: {trusted_proxies: []}", 0, false},
+		{"CIDRs", "server: {trusted_proxies: ['192.0.2.0/24', '2001:db8::/32']}", 2, false},
+		{"bare IP", "server: {trusted_proxies: ['192.0.2.1']}", 0, true},
+		{"invalid CIDR", "server: {trusted_proxies: ['192.0.2.0/99']}", 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("Load error = %v, want error = %v", err, tc.wantError)
+			}
+			if err == nil && len(cfg.Server.TrustedProxies) != tc.count {
+				t.Fatalf("got %d proxy prefixes, want %d", len(cfg.Server.TrustedProxies), tc.count)
+			}
+		})
+	}
+}
 
 func TestLoad_FileNotFound(t *testing.T) {
 	cfg, err := Load("/nonexistent/path/config.yaml")


### PR DESCRIPTION
## What this PR does

Closes #103. Direct clients can currently change supplied IP headers to bypass the WebSocket connection cap. Replace chi `RealIP` with a middleware that accepts one valid `X-Real-IP` only from a configured direct proxy peer. The default trust list is empty.

After resolving `RemoteAddr`, remove `True-Client-IP`, `X-Forwarded-For` and `X-Real-IP` for all peers so downstream middleware cannot reinterpret unvalidated headers. Other headers are preserved. Future rate limiting should use the resolved address (`KeyByIP`); #104/#105 remain separate.

Configuration loading rejects invalid, blank and null CIDR entries. The YAML decoder retains null entries for validation instead of silently discarding them. Missing/empty trust configuration logs one startup warning explaining the shared connection cap behind a proxy. The example includes Apache, nginx and Caddy header directives, `/32` and `/128` host notation, and guidance for additional proxy hops.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Docs / config

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l .` is empty
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New pure functions have unit tests
- [x] I have read `CONTRIBUTING.md`

No schema, REST contract, generated API, or dependency changes.

## Testing notes

The original WebSocket cap regression and the new configuration/header regressions fail before their respective fixes. Coverage includes empty/null entries, IPv4/IPv6, mapped IPv4, omitted trust, malformed/repeated/missing headers, preservation of unrelated headers, and distinct/same clients behind a trusted proxy.

Native Pi build/vet/full tests run with PostgreSQL enabled for the standalone PR and combined preview. Startup smoke checks run the actual binaries with missing/empty, valid, blank/null and bare-IP configurations. An intentionally invalid PostgreSQL port stops execution before any database, MQTT or listener access; these checks verify exactly one warning for missing/empty trust and rejection of invalid entries.

The [Pi preview](https://canadaverse.org/beacon-dev/source.html) includes these corrections at `37ceb6e99f2160d3826bc3eee92ee2f093ddb2bb`, alongside the reviewed #132 cursor fix. Live Caddy-chain checks cover direct, LAN, inner-proxy, trusted-tunnel and public HTTPS requests, plus WebSocket cap enforcement. The proxy snippets are checked against official documentation; the preview's existing proxy configuration is unchanged.

AI tools assisted implementation and validation under the contributor's standing approval for this effort.
