### PR TITLE
fix(api): return JSON 500 when bucketed telemetry query fails

### DIFF
--- a/internal/api/handlers/observers.go
+++ b/internal/api/handlers/observers.go
@@ -222,7 +222,8 @@ func getObserverTelemetry(reader api.Reader) http.HandlerFunc {
 		if bucketHours == 0 {
 			telemetry, err = reader.GetObserverTelemetry(r.Context(), observerID, since, until, afterID)
 		} else {
-			points, err := reader.GetObserverTelemetryBucketed(r.Context(), observerID, since, until, bucketHours)
+			var points []api.ObserverTelemetryPoint
+			points, err = reader.GetObserverTelemetryBucketed(r.Context(), observerID, since, until, bucketHours)
 			if err == nil {
 				telemetry = &api.ObserverTelemetry{Points: points}
 			}

--- a/internal/api/handlers/observers_test.go
+++ b/internal/api/handlers/observers_test.go
@@ -145,6 +145,29 @@ func TestGetObserverTelemetry_Bucketed_OK(t *testing.T) {
 	}
 }
 
+func TestGetObserverTelemetry_Bucketed_StoreError(t *testing.T) {
+	observerID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	r := chi.NewRouter()
+	r.Get("/observers/{observerId}/telemetry", getObserverTelemetry(stubReader{
+		getObserverTelemetryBucketed: func(_ context.Context, _ uuid.UUID, _, _ time.Time, _ int32) ([]api.ObserverTelemetryPoint, error) {
+			return nil, errors.New("boom")
+		},
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/observers/"+observerID.String()+"/telemetry?interval=6h", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	var body map[string]APIError
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("expected JSON error body, got %q: %v", w.Body.String(), err)
+	}
+	if body["error"].Code != "internal_server_error" {
+		t.Errorf("expected internal_server_error, got %q", body["error"].Code)
+	}
+}
+
 func TestListObserverAdverts_OK(t *testing.T) {
 	observerID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	r := chi.NewRouter()


### PR DESCRIPTION
## Summary

`getObserverTelemetry` declared a fresh `err` with `:=` inside the bucketed branch, so a failing `GetObserverTelemetryBucketed` never reached the outer error check. `telemetry` stayed nil and the handler panicked on `telemetry.Range = ...`; chi's recoverer turned that into a bare 500 with no `{"error": ...}` body. Only reachable with `interval=6h` or `24h`, the 7d/30d charts in beacon-web.

Assigns with `=` instead, and adds a handler test that stubs a store error on the bucketed path and asserts a JSON `internal_server_error` response. The test panics without the fix.

Closes the `telemetry-bucketed-error-panic` ticket in beacon-docs.
